### PR TITLE
feat: MviStore 및 샘플 코드 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
+    implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)

--- a/app/src/main/java/com/yapp/official/Example1ViewModel.kt
+++ b/app/src/main/java/com/yapp/official/Example1ViewModel.kt
@@ -1,0 +1,58 @@
+package com.yapp.official
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yapp.official.mvi.MviIntentStore
+import com.yapp.official.mvi.mviIntentStore
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+sealed interface ExampleIntent {
+    data object ClickIncrementButton : ExampleIntent
+    data object ClickDecrementButton : ExampleIntent
+    data class ClickLoadMoreButton(val startIndex: Int) : ExampleIntent
+}
+
+sealed interface ExampleSideEffect {
+    data class ShowMessage(val message: String) : ExampleSideEffect
+    data class ShowError(val error: String) : ExampleSideEffect
+}
+
+data class ExampleState(
+    val items: List<String> = emptyList(),
+    val isLoading: Boolean = false
+)
+
+class Example1ViewModel : ViewModel() {
+    private val loadMoreMutex = Mutex()
+
+    val store: MviIntentStore<ExampleState, ExampleIntent, ExampleSideEffect> =
+        mviIntentStore(
+            initialState = ExampleState(),
+            onIntent = { intent, state, setState, postSideEffect ->
+                when (intent) {
+                    ExampleIntent.ClickDecrementButton -> postSideEffect(ExampleSideEffect.ShowMessage("Decrement"))
+                    ExampleIntent.ClickIncrementButton -> postSideEffect(ExampleSideEffect.ShowMessage("Increment"))
+                    is ExampleIntent.ClickLoadMoreButton -> loadMoreItem(intent, setState, postSideEffect)
+                }
+            }
+        )
+
+    private fun loadMoreItem(
+        intent: ExampleIntent.ClickLoadMoreButton,
+        setState: (ExampleState.() -> ExampleState) -> Unit,
+        postSideEffect: (ExampleSideEffect) -> Unit
+    ) = viewModelScope.launch {
+        if (loadMoreMutex.isLocked) return@launch
+
+        loadMoreMutex.withLock {
+            setState { copy(isLoading = true) }
+            delay(3000)
+            val newItems = List(10) { "Item ${intent.startIndex + it}" }
+            setState { copy(items = items + newItems, isLoading = false) }
+            postSideEffect(ExampleSideEffect.ShowMessage("Load Success"))
+        }
+    }
+}

--- a/app/src/main/java/com/yapp/official/Example2ViewModel.kt
+++ b/app/src/main/java/com/yapp/official/Example2ViewModel.kt
@@ -1,0 +1,41 @@
+package com.yapp.official
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yapp.official.mvi.MviStore
+import com.yapp.official.mvi.mviStore
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class Example2ViewModel : ViewModel() {
+    private val loadMoreMutex = Mutex()
+
+    val store: MviStore<ExampleState, ExampleSideEffect> =
+        mviStore(
+            initialState = ExampleState(),
+        )
+
+    fun onClickDecrementButton() {
+        store.postSideEffect(ExampleSideEffect.ShowMessage("Decrement"))
+    }
+
+    fun onClickIncrementButton() {
+        store.postSideEffect(ExampleSideEffect.ShowMessage("Increment"))
+    }
+
+    fun onClickLoadMoreButton(
+        startIndex: Int
+    ) = viewModelScope.launch {
+        if(loadMoreMutex.isLocked) return@launch
+
+        loadMoreMutex.withLock {
+            store.setState { copy(isLoading = true) }
+            delay(3000)
+            val newItems = List(10) { "Item ${startIndex + it}" }
+            store.setState { copy(items = items + newItems, isLoading = false) }
+            store.postSideEffect(ExampleSideEffect.ShowMessage("Load Success"))
+        }
+    }
+}

--- a/app/src/main/java/com/yapp/official/Flow.kt
+++ b/app/src/main/java/com/yapp/official/Flow.kt
@@ -1,0 +1,23 @@
+package com.yapp.official
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+
+@Composable
+inline fun <reified T> Flow<T>.collectWithLifecycle(
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
+    noinline action: suspend (T) -> Unit,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(this, lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
+            this@collectWithLifecycle.collect { action(it) }
+        }
+    }
+}

--- a/app/src/main/java/com/yapp/official/MainActivity.kt
+++ b/app/src/main/java/com/yapp/official/MainActivity.kt
@@ -1,16 +1,25 @@
 package com.yapp.official
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.yapp.official.ui.theme.YappOfficialTheme
 
 class MainActivity : ComponentActivity() {
@@ -20,10 +29,8 @@ class MainActivity : ComponentActivity() {
         setContent {
             YappOfficialTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+//                    Example1Screen(modifier = Modifier.padding(innerPadding))
+                    Example2Screen(modifier = Modifier.padding(innerPadding))
                 }
             }
         }
@@ -31,17 +38,134 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
+fun Example1Screen(
+    modifier: Modifier = Modifier,
+    viewModel: Example1ViewModel = viewModel()
+) {
+    val uiState by viewModel.store.uiState.collectAsState() // TODO WithLifeCycle
+
+    val context = LocalContext.current
+    viewModel.store.sideEffects.collectWithLifecycle { effect ->
+        when (effect) {
+            is ExampleSideEffect.ShowMessage -> {
+                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+            }
+            is ExampleSideEffect.ShowError -> {
+                Toast.makeText(context, effect.error, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    Column(
+        modifier = modifier,
+    ) {
+        Text(text = "Current Items: ${uiState.items.size}")
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = {
+                viewModel.store.onIntent(ExampleIntent.ClickIncrementButton)
+            }
+        ) {
+            Text("Increment")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = {
+                viewModel.store.onIntent(ExampleIntent.ClickDecrementButton)
+            }
+        ) {
+            Text("Decrement")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = {
+                val startIndex = uiState.items.size
+                viewModel.store.onIntent(ExampleIntent.ClickLoadMoreButton(startIndex))
+            }
+        ) {
+            Text("Load More Items")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (uiState.isLoading) {
+            Text("Loading...")
+        }
+
+        uiState.items.forEach { item ->
+            Text(item)
+        }
+    }
 }
 
-@Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
-    YappOfficialTheme {
-        Greeting("Android")
+fun Example2Screen(
+    modifier: Modifier = Modifier,
+    viewModel: Example2ViewModel = viewModel()
+) {
+    val uiState by viewModel.store.uiState.collectAsState() // TODO WithLifeCycle
+
+    val context = LocalContext.current
+    viewModel.store.sideEffects.collectWithLifecycle { effect ->
+        when (effect) {
+            is ExampleSideEffect.ShowMessage -> {
+                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+            }
+            is ExampleSideEffect.ShowError -> {
+                Toast.makeText(context, effect.error, Toast.LENGTH_SHORT).show()
+            }
+        }
+
+    }
+
+    Column(
+        modifier = modifier,
+    ) {
+        Text(text = "Current Items: ${uiState.items.size}")
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = {
+                viewModel.onClickIncrementButton()
+            }
+        ) {
+            Text("Increment")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = {
+                viewModel.onClickDecrementButton()
+            }
+        ) {
+            Text("Decrement")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = {
+                val startIndex = uiState.items.size
+                viewModel.onClickLoadMoreButton(startIndex)
+            }
+        ) {
+            Text("Load More Items")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (uiState.isLoading) {
+            Text("Loading...")
+        }
+
+        uiState.items.forEach { item ->
+            Text(item)
+        }
     }
 }

--- a/app/src/main/java/com/yapp/official/mvi/MviIntentStore.kt
+++ b/app/src/main/java/com/yapp/official/mvi/MviIntentStore.kt
@@ -1,0 +1,64 @@
+package com.yapp.official.mvi
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+interface MviIntentStore<STATE, INTENT, EFFECT> {
+    val uiState: StateFlow<STATE>
+    val sideEffects: Flow<EFFECT>
+
+    fun onIntent(intent: INTENT)
+}
+
+class MviIntentStoreImpl<STATE, INTENT, EFFECT>(
+    initialState: STATE,
+    private val coroutineScope: CoroutineScope,
+    private val onIntent: (
+        intent: INTENT,
+        state: STATE,
+        reduce: (STATE.() -> STATE) -> Unit,
+        postSideEffect: (EFFECT) -> Unit
+    ) -> Unit
+) : MviIntentStore<STATE, INTENT, EFFECT> {
+
+    private val _uiState = MutableStateFlow(initialState)
+    override val uiState: StateFlow<STATE> = _uiState.asStateFlow()
+
+    private val _sideEffects = Channel<EFFECT>(Channel.BUFFERED)
+    override val sideEffects: Flow<EFFECT> = _sideEffects.receiveAsFlow()
+
+    private fun setState(reduce: STATE.() -> STATE) {
+        _uiState.update(reduce)
+    }
+
+    private fun postSideEffect(effect: EFFECT) {
+        coroutineScope.launch { _sideEffects.send(effect) }
+    }
+
+    override fun onIntent(intent: INTENT) {
+        onIntent(
+            intent,
+            _uiState.value,
+            { reduce -> setState { reduce() } },
+            { effect -> postSideEffect(effect) }
+        )
+    }
+}
+
+fun <STATE, INTENT, EFFECT> ViewModel.mviIntentStore(
+    initialState: STATE,
+    onIntent: (INTENT, STATE, (STATE.() -> STATE) -> Unit, (EFFECT) -> Unit) -> Unit
+): MviIntentStore<STATE, INTENT, EFFECT> = MviIntentStoreImpl(
+    initialState = initialState,
+    coroutineScope = viewModelScope,
+    onIntent = onIntent
+)

--- a/app/src/main/java/com/yapp/official/mvi/MviStore.kt
+++ b/app/src/main/java/com/yapp/official/mvi/MviStore.kt
@@ -1,0 +1,53 @@
+package com.yapp.official.mvi
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+interface MviStore<STATE, EFFECT> {
+    val uiState: StateFlow<STATE>
+    val sideEffects: Flow<EFFECT>
+
+    fun setState(reduce: STATE.() -> STATE)
+    fun postSideEffect(effect: EFFECT)
+}
+
+class MviStoreImpl<STATE, EFFECT>(
+    initialUiState: STATE,
+    private val coroutineScope: CoroutineScope,
+) : MviStore<STATE, EFFECT> {
+
+    private val _uiState = MutableStateFlow(initialUiState)
+    override val uiState: StateFlow<STATE> = _uiState.asStateFlow()
+
+    private val _sideEffects = Channel<EFFECT>()
+    override val sideEffects: Flow<EFFECT> = _sideEffects.receiveAsFlow()
+
+    override fun setState(reduce: STATE.() -> STATE) {
+        _uiState.update(reduce)
+    }
+
+    override fun postSideEffect(effect: EFFECT) {
+        coroutineScope.launch {
+            _sideEffects.send(effect)
+        }
+    }
+}
+
+fun <STATE, EFFECT> ViewModel.mviStore(
+    initialState: STATE
+): MviStore<STATE, EFFECT> = MviStoreImpl(
+    initialUiState = initialState,
+    coroutineScope = viewModelScope,
+)
+
+
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.04.01"
+lifecycle = "2.6.1" # Lifecycle 및 ViewModel 버전
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -17,6 +18,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #이슈번호

## 🌱 Key changes
<!--변경사항 적기-->

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
MVI의 Model은 앱의 상태를 나타내고, 앱의 상태를 어디까지 보는지에 대한 견해는 각각 다른 것 같습니다.
앱의 상태를 컴포즈 Screen으로 볼지, 아니면 Screen을 넘어선 환경 (Activity?)로 볼지에 대한 견해가 있는걸로 아는데요
저는 앱의 상태를 컴포즈 Screen으로 봤습니다. (이유는 [여기](https://disquiet.io/@jinukeu/makerlog/%EC%82%AC%EC%9D%B4%EB%93%9C-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%EC%97%90%EC%84%9C-mvi-%EC%8D%A8%EB%B3%B8-%EC%8D%B0))

### MviStore
- 기존 얍 출석 앱과 비슷

### MviIntentStore
- [Stop Passing Event/UI-Action Callbacks in Jetpack Compose](https://engineering.teknasyon.com/stop-passing-event-ui-action-callbacks-in-jetpack-compose-a4143621c365) 응용
- 위 링크를 사용하게 되면 Intent를 거치지 않고도 상태와 사이드이펙트를 보낼 수 있게됨
- 따라서 Intent를 통해서만 앱의 상태를 업데이트 하고 사이드 이펙트를 처리할 수 있게함

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 앱에 상호작용 가능한 화면 추가
	- 항목 증가, 감소, 로드 기능 구현

- **종속성 업데이트**
	- Jetpack Compose ViewModel 라이브러리 추가

- **아키텍처 개선**
	- MVI(Model-View-Intent) 아키텍처 도입
	- 상태 관리 및 부수 효과 처리 메커니즘 구현

- **UI 변경**
	- 기존 인사말 화면 대신 새로운 예제 화면으로 대체

<!-- end of auto-generated comment: release notes by coderabbit.ai -->