### PR TITLE
Feature/#22 Network Setting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.YappOfficial"
-        tools:targetApi="31"
-        android:usesCleartextTraffic="true"> <!-- TODO REMOVE!! -->
+        tools:targetApi="31">
 
         <activity
             android:name="com.yapp.app.official.MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name="com.yapp.app.official.YappOfficialApplication"
@@ -12,7 +13,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.YappOfficial"
-        tools:targetApi="31">
+        tools:targetApi="31"
+        android:usesCleartextTraffic="true"> <!-- TODO REMOVE!! -->
 
         <activity
             android:name="com.yapp.app.official.MainActivity"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,5 +8,4 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
-    alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/core/data-api/build.gradle.kts
+++ b/core/data-api/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("yapp.kotlin.library")
 }
+
+dependencies {
+    implementation(project(":core:model"))
+}

--- a/core/data-api/src/main/java/com/yapp/data_api/UnAuthorizedUserRepository.kt
+++ b/core/data-api/src/main/java/com/yapp/data_api/UnAuthorizedUserRepository.kt
@@ -1,0 +1,10 @@
+package com.yapp.data_api
+
+import com.yapp.model.SignUpInfo
+import com.yapp.model.YappJWT
+
+interface UnAuthorizedUserRepository {
+    suspend fun signUp(
+        request: SignUpInfo,
+    ): YappJWT?
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -3,6 +3,7 @@ import com.yapp.app.setNamespace
 plugins {
     id("yapp.android.library")
     id("yapp.android.hilt")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android{
@@ -14,4 +15,9 @@ dependencies {
     implementation(project(":core:data-api"))
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.kotlin.serialization)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp.logging)
+    implementation(libs.timber)
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -3,7 +3,6 @@ import com.yapp.app.setNamespace
 plugins {
     id("yapp.android.library")
     id("yapp.android.hilt")
-    alias(libs.plugins.kotlin.serialization)
 }
 
 android{
@@ -17,7 +16,6 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.kotlin.serialization)
-    implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp.logging)
     implementation(libs.timber)
 }

--- a/core/data/src/main/java/com/yapp/core/data/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/yapp/core/data/data/di/RepositoryModule.kt
@@ -1,0 +1,18 @@
+package com.yapp.core.data.data.di
+
+import com.yapp.core.data.data.repository.UnAuthorizedUserRepositoryImpl
+import com.yapp.data_api.UnAuthorizedUserRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class RepositoryModule {
+
+    @Binds
+    abstract fun bindTokenRepository(
+        tokenRepositoryImpl: UnAuthorizedUserRepositoryImpl,
+    ): UnAuthorizedUserRepository
+}

--- a/core/data/src/main/java/com/yapp/core/data/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/yapp/core/data/data/di/RepositoryModule.kt
@@ -12,7 +12,7 @@ import dagger.hilt.components.SingletonComponent
 internal abstract class RepositoryModule {
 
     @Binds
-    abstract fun bindTokenRepository(
-        tokenRepositoryImpl: UnAuthorizedUserRepositoryImpl,
+    abstract fun bindUnAuthorizedUserRepositoryImpl(
+        unAuthorizedUserRepositoryImpl: UnAuthorizedUserRepositoryImpl,
     ): UnAuthorizedUserRepository
 }

--- a/core/data/src/main/java/com/yapp/core/data/data/repository/UnAuthorizedUserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/yapp/core/data/data/repository/UnAuthorizedUserRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.yapp.core.data.data.repository
+
+import com.yapp.core.data.remote.api.UnAuthorizedUserApi
+import com.yapp.core.data.remote.model.request.toData
+import com.yapp.data_api.UnAuthorizedUserRepository
+import com.yapp.model.SignUpInfo
+import com.yapp.model.YappJWT
+import javax.inject.Inject
+import kotlin.jvm.optionals.getOrNull
+
+internal class UnAuthorizedUserRepositoryImpl @Inject constructor(
+    private val api: UnAuthorizedUserApi,
+): UnAuthorizedUserRepository {
+    override suspend fun signUp(request: SignUpInfo): YappJWT? {
+        return api.signUp(
+            request.toData()
+        ).getOrNull()?.toModel()
+    }
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/Constant.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/Constant.kt
@@ -1,0 +1,5 @@
+package com.yapp.core.data.remote
+
+internal object Tag {
+    internal const val Retrofit = "Retrofit"
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/api/UnAuthorizedUserApi.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/api/UnAuthorizedUserApi.kt
@@ -1,0 +1,14 @@
+package com.yapp.core.data.remote.api
+
+import com.yapp.core.data.remote.model.request.SignUpRequest
+import com.yapp.core.data.remote.model.response.SignUpResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+import java.util.Optional
+
+interface UnAuthorizedUserApi {
+    @POST("v1/auth/sign-up")
+    suspend fun signUp(
+        @Body request: SignUpRequest,
+    ): Optional<SignUpResponse>
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/di/ApiServiceModule.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/di/ApiServiceModule.kt
@@ -1,0 +1,20 @@
+package com.yapp.core.data.remote.di
+
+import com.yapp.core.data.remote.api.UnAuthorizedUserApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ApiServiceModule {
+
+    @Singleton
+    @Provides
+    fun provideAuthService(retrofit: Retrofit): UnAuthorizedUserApi {
+        return retrofit.create(UnAuthorizedUserApi::class.java)
+    }
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/di/ApiServiceModule.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/di/ApiServiceModule.kt
@@ -14,7 +14,7 @@ object ApiServiceModule {
 
     @Singleton
     @Provides
-    fun provideAuthService(retrofit: Retrofit): UnAuthorizedUserApi {
+    fun provideUnAuthorizedUserApi(retrofit: Retrofit): UnAuthorizedUserApi {
         return retrofit.create(UnAuthorizedUserApi::class.java)
     }
 }

--- a/core/data/src/main/java/com/yapp/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/di/NetworkModule.kt
@@ -1,0 +1,82 @@
+package com.yapp.core.data.remote.di
+
+import android.util.Log
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.yapp.core.data.remote.Tag
+import com.yapp.core.data.remote.retrofit.ResultCallAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.encodeToString
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.json.JSONArray
+import org.json.JSONObject
+import retrofit2.Retrofit
+import timber.log.Timber
+import javax.inject.Singleton
+import kotlinx.serialization.json.Json
+import retrofit2.OptionalConverterFactory
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    private const val BASE_URL = "https://dev-yappuworld.yapp.co.kr/"
+
+    @Singleton
+    @Provides
+    fun provideLoggingInterceptor(
+        json: Json,
+    ): HttpLoggingInterceptor = HttpLoggingInterceptor { message ->
+        when {
+            !message.isJsonObject() && !message.isJsonArray() ->
+                Timber.tag(Tag.Retrofit).d("CONNECTION INFO -> $message")
+            else -> kotlin.runCatching {
+                json.encodeToString(Json.parseToJsonElement(message))
+            }.onSuccess {
+                Timber.tag(Tag.Retrofit).d(it)
+            }.onFailure {
+                Timber.tag(Tag.Retrofit).d(message)
+            }
+        }
+    }.apply { level = HttpLoggingInterceptor.Level.BODY }
+
+    @Singleton
+    @Provides
+    fun provideOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .build()
+
+    @Singleton
+    @Provides
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        json: Json,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .addCallAdapterFactory(ResultCallAdapterFactory())
+        .addConverterFactory(OptionalConverterFactory.create())
+        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .client(okHttpClient)
+        .build()
+
+    @Singleton
+    @Provides
+    fun provideJson(): Json {
+        return Json {
+            prettyPrint = true
+            coerceInputValues = true
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
+    }
+}
+
+private fun String.isJsonObject(): Boolean = runCatching { JSONObject(this) }.isSuccess
+
+private fun String.isJsonArray(): Boolean = runCatching { JSONArray(this) }.isSuccess

--- a/core/data/src/main/java/com/yapp/core/data/remote/model/request/SignUpRequest.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/model/request/SignUpRequest.kt
@@ -1,0 +1,33 @@
+package com.yapp.core.data.remote.model.request
+
+import com.yapp.model.ActivityUnitModel
+import com.yapp.model.SignUpInfo
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignUpRequest(
+    val email: String,
+    val password: String,
+    val name: String,
+    val activityUnits: List<ActivityUnit>,
+    val signUpCode: String
+)
+
+@Serializable
+data class ActivityUnit(
+    val generation: Int,
+    val position: String
+)
+
+fun SignUpInfo.toData() = SignUpRequest(
+    email = email,
+    password = password,
+    name = name,
+    activityUnits = activityUnits.map { it.toData() },
+    signUpCode = signUpCode
+)
+
+fun ActivityUnitModel.toData() = ActivityUnit(
+    generation = generation,
+    position = position,
+)

--- a/core/data/src/main/java/com/yapp/core/data/remote/model/response/SignUpResponse.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/model/response/SignUpResponse.kt
@@ -1,0 +1,15 @@
+package com.yapp.core.data.remote.model.response
+
+import com.yapp.model.YappJWT
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignUpResponse(
+    val accessToken: String,
+    val refreshToken: String,
+) {
+    fun toModel() = YappJWT(
+        accessToken = accessToken,
+        refreshToken = refreshToken
+    )
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/retrofit/ApiResultCallAdapter.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/retrofit/ApiResultCallAdapter.kt
@@ -1,0 +1,92 @@
+package com.yapp.core.data.remote.retrofit
+
+import com.yapp.model.exceptions.YappServerError
+import kotlinx.serialization.json.Json
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.Response
+import java.lang.reflect.Type
+
+internal class ApiResultCallAdapter<R>(
+    private val successType: Type,
+) : CallAdapter<R, Call<R>> {
+    override fun adapt(call: Call<R>): Call<R> = ApiResultCall(call, successType)
+    override fun responseType(): Type = successType
+}
+
+private class ApiResultCall<R>(
+    private val delegate: Call<R>,
+    private val successType: Type,
+) : Call<R> {
+
+    override fun enqueue(callback: Callback<R>) = delegate.enqueue(
+        object : Callback<R> {
+            override fun onResponse(call: Call<R>, response: Response<R>) {
+                if (response.isSuccessful.not()) {
+                    handleHttpError(response, callback)
+                    return
+                }
+
+                @Suppress("UNCHECKED_CAST")
+                val body = response.body() as? YappResponse<R>
+
+                if (body != null) {
+                    callback.onResponse(this@ApiResultCall, Response.success(body.data))
+                    return
+                }
+
+                return if (successType == Unit::class.java) {
+                    @Suppress("UNCHECKED_CAST")
+                    callback.onResponse(this@ApiResultCall, Response.success(Unit as R))
+                } else {
+                    callback.onFailure(
+                        this@ApiResultCall,
+                        Exception("Body가 존재하지 않지만, Unit 이외의 타입으로 정의했습니다.")
+                    )
+                }
+            }
+
+            override fun onFailure(call: Call<R>, throwable: Throwable) {
+                callback.onFailure(this@ApiResultCall, throwable)
+            }
+        },
+    )
+
+    private fun handleHttpError(response: Response<R>, callback: Callback<R>) {
+        kotlin.runCatching {
+            val errorBody = response.errorBody()?.string()
+            json.decodeFromString<YappErrorResponse>(errorBody!!)
+        }.onSuccess { errorBody ->
+            val exception = YappServerError
+                .valueOf(errorBody.errorCode)
+                .exception
+                .apply { setMessage(message) }
+            callback.onFailure(this@ApiResultCall, exception)
+        }.onFailure {
+            val exception = handleCommonError(response.code())
+            callback.onFailure(this@ApiResultCall, exception)
+        }
+    }
+
+    override fun clone(): Call<R> = ApiResultCall(delegate.clone(), successType)
+
+    override fun execute(): Response<R> =
+        throw UnsupportedOperationException("This adapter doesn't support sync execution")
+
+    override fun isExecuted(): Boolean = delegate.isExecuted
+
+    override fun cancel() = delegate.cancel()
+
+    override fun isCanceled(): Boolean = delegate.isCanceled
+
+    override fun request(): Request = delegate.request()
+
+    override fun timeout(): Timeout = delegate.timeout()
+
+    companion object {
+        private val json = Json { encodeDefaults = true }
+    }
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/retrofit/OptionalApiResultCallAdapter.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/retrofit/OptionalApiResultCallAdapter.kt
@@ -1,0 +1,102 @@
+package com.yapp.core.data.remote.retrofit
+
+import com.yapp.model.exceptions.YappServerError
+import kotlinx.serialization.json.Json
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.Response
+import java.lang.reflect.Type
+import java.util.Optional
+
+internal class OptionalApiResultCallAdapter<R: Any>(
+    private val successType: Type,
+) : CallAdapter<R, Call<Optional<R>>> {
+    override fun adapt(call: Call<R>): Call<Optional<R>> = OptionalApiResultCall(call, successType)
+    override fun responseType(): Type = successType
+}
+
+private class OptionalApiResultCall<R: Any>(
+    private val delegate: Call<R>,
+    private val successType: Type,
+) : Call<Optional<R>> {
+
+    override fun enqueue(callback: Callback<Optional<R>>) = delegate.enqueue(
+        object : Callback<R> {
+            override fun onResponse(call: Call<R>, response: Response<R>) {
+                if (response.isSuccessful.not()) {
+                    handleHttpError(response, callback)
+                    return
+                }
+
+                val body = response.body()
+
+                if (body != null) {
+                    @Suppress("UNCHECKED_CAST")
+                    callback.onResponse(
+                        this@OptionalApiResultCall,
+                        Response.success(
+                            Optional.ofNullable((body as YappResponse<R>).data)
+                        )
+                    )
+                    return
+                }
+
+                return if (successType == Unit::class.java) {
+                    @Suppress("UNCHECKED_CAST")
+                    callback.onResponse(this@OptionalApiResultCall, Response.success(Optional.ofNullable(Unit as R)))
+                } else {
+                    callback.onFailure(
+                        this@OptionalApiResultCall,
+                        Exception("Body가 존재하지 않지만, Unit 이외의 타입으로 정의했습니다.")
+                    )
+                }
+
+            }
+
+            override fun onFailure(call: Call<R>, throwable: Throwable) {
+                callback.onFailure(this@OptionalApiResultCall, throwable)
+            }
+        },
+    )
+
+    private fun handleHttpError(
+        response: Response<R>,
+        callback: Callback<Optional<R>>
+    ) {
+        kotlin.runCatching {
+            val errorBody = response.errorBody()?.string()
+            json.decodeFromString<YappErrorResponse>(errorBody!!)
+        }.onSuccess { errorBody ->
+            val exception = YappServerError
+                .valueOf(errorBody.errorCode)
+                .exception
+                .apply { setMessage(message) }
+            callback.onFailure(this@OptionalApiResultCall, exception)
+        }.onFailure {
+            val exception = handleCommonError(response.code())
+            callback.onFailure(this@OptionalApiResultCall, exception)
+        }
+    }
+
+    override fun clone(): Call<Optional<R>> = OptionalApiResultCall(delegate.clone(), successType)
+
+    override fun execute(): Response<Optional<R>> =
+        throw UnsupportedOperationException("This adapter doesn't support sync execution")
+
+    override fun isExecuted(): Boolean = delegate.isExecuted
+
+    override fun cancel() = delegate.cancel()
+
+    override fun isCanceled(): Boolean = delegate.isCanceled
+
+    override fun request(): Request = delegate.request()
+
+    override fun timeout(): Timeout = delegate.timeout()
+
+    companion object {
+        private val json = Json { encodeDefaults = true }
+    }
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/retrofit/ResultCallAdapterFactory.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/retrofit/ResultCallAdapterFactory.kt
@@ -1,0 +1,49 @@
+package com.yapp.core.data.remote.retrofit
+
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.Optional
+
+class ResultCallAdapterFactory : CallAdapter.Factory() {
+
+    override fun get(
+        returnType: Type,
+        annotations: Array<Annotation>,
+        retrofit: Retrofit
+    ): CallAdapter<*, *>? {
+        if (getRawType(returnType) != Call::class.java) {
+            return null
+        }
+
+        val innerType = getParameterUpperBound(0, returnType as ParameterizedType)
+
+        val isOptional = (getRawType(innerType) == Optional::class.java)
+        val actualType = if (isOptional && innerType is ParameterizedType) {
+            getParameterUpperBound(0, innerType)
+        } else {
+            innerType
+        }
+
+        val baseResponseType = object : ParameterizedType {
+            override fun getRawType(): Type = YappResponse::class.java
+            override fun getOwnerType(): Type? = null
+            override fun getActualTypeArguments(): Array<Type> = arrayOf(actualType)
+        }
+
+        return apiResultAdapter(baseResponseType, innerType)
+    }
+
+    private fun apiResultAdapter(
+        returnType: ParameterizedType,
+        innerType: Type
+    ): CallAdapter<Type, out Call<out Any>> {
+        return if (getRawType(innerType) == Optional::class.java) {
+            OptionalApiResultCallAdapter(returnType)
+        } else {
+            ApiResultCallAdapter(returnType)
+        }
+    }
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/retrofit/Util.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/retrofit/Util.kt
@@ -1,0 +1,15 @@
+package com.yapp.core.data.remote.retrofit
+
+import com.yapp.model.exceptions.ForbiddenException
+import com.yapp.model.exceptions.NetworkException
+import com.yapp.model.exceptions.NotFoundException
+import com.yapp.model.exceptions.RequestFailException
+import com.yapp.model.exceptions.UnknownException
+
+internal fun handleCommonError(httpStatusCode: Int) = when (httpStatusCode) {
+    400 -> RequestFailException()
+    403 -> ForbiddenException()
+    404 -> NotFoundException()
+    500, 501, 502, 503, 504, 505 -> NetworkException()
+    else -> UnknownException()
+}

--- a/core/data/src/main/java/com/yapp/core/data/remote/retrofit/YappErrorResponse.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/retrofit/YappErrorResponse.kt
@@ -1,0 +1,10 @@
+package com.yapp.core.data.remote.retrofit
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class YappErrorResponse(
+    val isSuccess: Boolean,
+    val errorCode: String,
+    val message: String
+)

--- a/core/data/src/main/java/com/yapp/core/data/remote/retrofit/YappResponse.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/retrofit/YappResponse.kt
@@ -1,0 +1,9 @@
+package com.yapp.core.data.remote.retrofit
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class YappResponse<T>(
+    val data: T? = null
+)
+

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
     implementation(project(":core:data-api"))
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.hilt.core)
 }

--- a/core/domain/src/main/java/com/yapp/domain/SignUpUseCase.kt
+++ b/core/domain/src/main/java/com/yapp/domain/SignUpUseCase.kt
@@ -1,0 +1,13 @@
+package com.yapp.domain
+
+import com.yapp.data_api.UnAuthorizedUserRepository
+import com.yapp.model.SignUpInfo
+import javax.inject.Inject
+
+class SignUpUseCase @Inject constructor(
+    private val signUpRepository: UnAuthorizedUserRepository,
+) {
+    suspend operator fun invoke(param: SignUpInfo) = kotlin.runCatching {
+        signUpRepository.signUp(param)
+    }
+}

--- a/core/model/src/main/java/com/yapp/model/MyClass.kt
+++ b/core/model/src/main/java/com/yapp/model/MyClass.kt
@@ -1,4 +1,0 @@
-package com.yapp.model
-
-class MyClass {
-}

--- a/core/model/src/main/java/com/yapp/model/SignUpRequest.kt
+++ b/core/model/src/main/java/com/yapp/model/SignUpRequest.kt
@@ -1,0 +1,19 @@
+package com.yapp.model
+
+data class SignUpInfo(
+    val email: String,
+    val password: String,
+    val name: String,
+    val activityUnits: List<ActivityUnitModel>,
+    val signUpCode: String
+)
+
+data class ActivityUnitModel(
+    val generation: Int,
+    val position: String
+)
+
+data class YappJWT(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/core/model/src/main/java/com/yapp/model/exceptions/CommonExceptions.kt
+++ b/core/model/src/main/java/com/yapp/model/exceptions/CommonExceptions.kt
@@ -1,0 +1,21 @@
+package com.yapp.model.exceptions
+
+class RequestFailException(
+    override val message: String = "요청을 처리하지 못했어요.",
+) : RuntimeException()
+
+class ForbiddenException(
+    override val message: String = "제한된 요청이에요.",
+) : RuntimeException()
+
+class NotFoundException(
+    override val message: String = "정보를 찾을 수 없어요.",
+) : RuntimeException()
+
+class NetworkException(
+    override val message: String = "네트워크 연결 상태 또는 수수 서버에 문제가 있어요.",
+) : RuntimeException()
+
+class UnknownException(
+    override val message: String = "알 수 없는 에러가 발생했어요.",
+) : RuntimeException()

--- a/core/model/src/main/java/com/yapp/model/exceptions/YappExceptions.kt
+++ b/core/model/src/main/java/com/yapp/model/exceptions/YappExceptions.kt
@@ -1,0 +1,24 @@
+package com.yapp.model.exceptions
+
+enum class YappServerError(val exception: YappException) {
+    USR_1001(SignUpCodeException()),
+    USR_1002(AlreadyRegisteredException()),
+    USR_1003(UnprocessedSignUpException()),
+}
+
+class SignUpCodeException() : YappException("잘못된 가입코드입니다.")
+class AlreadyRegisteredException() : YappException("이미 가입된 이메일입니다.")
+class UnprocessedSignUpException() : YappException("처리되지 않은 가입 신청이 존재하여, 추가 가입 신청이 불가합니다.")
+
+open class YappException(message: String = "") : Exception(message) {
+    private var _message: String = message
+
+    override val message: String
+        get() = _message
+
+    fun setMessage(newMessage: String) {
+        _message = newMessage
+    }
+}
+
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,11 @@ hilt = "2.51.1"
 ksp = "2.0.0-1.0.22"
 navigationCompose = "2.8.5"
 
+retrofit = "2.11.0"
+retrofitKotlinxSerializationJson = "1.0.0"
+okhttp = "4.12.0"
+
+timber = "5.0.1"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -43,7 +48,6 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
-
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -51,6 +55,13 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationCompose" }
+hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
+
+retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationJson" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+
+timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #22

## 🌱 Key changes
<!--변경사항 적기-->
- Retrofit CustomCallAdapterFactory 구현했습니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
커밋은 ... 못쪼갰습니다 ㅜㅜ 죄송해요
- 사용 예시는 `UnAuthorizedUserApi` 보시면 될 듯 합니다.
- 서버에서 내려주는 json의 data가 nullable한 경우 `Optional` 사용하시면 됩니다. (RetrofitCallAdapter에서 nullable 타입을 인지하지 못하는 문제가 있었습니다 ... ㅜ)

- Response 객체는 data에 해당하는 스키마만 만드시면 됩니다.
```
예를 들어 스웨거 응답값이 아래와 같다면 ...
{
  "isSuccess": "true",
  "data": {
    "accessToken": "accessToken...",
    "refreshToken": "refreshToken..."
  }
}

이것만 구현하시면 됩니다.
 {
    "accessToken": "accessToken...",
    "refreshToken": "refreshToken..."
  }
```

- 사용 예시입니다.
```kotlin
            useCase(
                SignUpInfo(
                    email = "test60@test.com",
                    password = "password",
                    name = "name",
                    activityUnits = listOf(ActivityUnitModel(0, "PM")),
                    signUpCode = ""
                )
            ).onSuccess {
                
            }.onFailure {
                when (it) {
                    is SignUpCodeException -> Unit
                    is UnprocessedSignUpException -> Unit
                    is AlreadyRegisteredException -> Unit
                }
            }
```

### 나중에 변경할 것들
- Repository, UseCase 등의 로직
- data 모듈의 접근 제어자를 internal로 설정
- Timber 세팅

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- 사용자 회원가입 기능 추가
	- 네트워크 통신을 위한 인터넷 권한 요청 추가

- **의존성 업데이트**
	- Retrofit, OkHttp, Timber 라이브러리 추가
	- Hilt 종속성 관리 개선

- **보안 및 오류 처리**
	- 네트워크 오류 및 예외 처리 메커니즘 강화
	- 사용자 인증 및 토큰 관리 기능 도입

<!-- end of auto-generated comment: release notes by coderabbit.ai -->