### PR TITLE
Featrue/#37 HeaderActionbar component

### DIFF
--- a/core/designsystem/src/main/java/com/yapp/core/designsystem/component/header/HeaderActionbar.kt
+++ b/core/designsystem/src/main/java/com/yapp/core/designsystem/component/header/HeaderActionbar.kt
@@ -1,0 +1,122 @@
+package com.yapp.core.designsystem.component.header
+
+import android.graphics.drawable.Icon
+import android.provider.MediaStore.Images
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.yapp.core.designsystem.theme.YappTheme
+
+@Composable
+fun HeaderActionbar(
+    modifier: Modifier = Modifier,
+    leftIcon: @Composable (() -> Unit)? = null,
+    rightAction: @Composable (RowScope.() -> Unit)? = null,
+    title: String? = null,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp, horizontal = 20.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        if (title != null) {
+            Text(
+                text = title,
+                style = YappTheme.typography.heading1Bold,
+                color = YappTheme.colorScheme.labelNormal,
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            leftIcon?.invoke()
+
+            rightAction?.invoke(this)
+        }
+    }
+}
+
+@Composable
+fun HeaderActionbarExpanded(
+    modifier: Modifier = Modifier,
+    leftIcon: @Composable (() -> Unit)? = null,
+    rightAction: @Composable (RowScope.() -> Unit)? = null,
+    title: String,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp, horizontal = 20.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            leftIcon?.invoke()
+
+            rightAction?.invoke(this)
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            text = title,
+            style = YappTheme.typography.title3Bold,
+            color = YappTheme.colorScheme.labelNormal,
+        )
+    }
+}
+
+@Preview(backgroundColor = 0xFFFFFFFF, showBackground = true)
+@Composable
+private fun HeaderActionbarPreview() {
+    YappTheme {
+        HeaderActionbar(
+            leftIcon = {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = null
+                )
+            },
+            title = "Title"
+        )
+    }
+}
+
+@Preview(backgroundColor = 0xFFFFFFFF, showBackground = true)
+@Composable
+private fun HeaderActionbarExpandedPreview() {
+    YappTheme {
+        HeaderActionbarExpanded(
+            leftIcon = {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = null
+                )
+            },
+            title = "Title"
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/yapp/core/designsystem/extension/Modifier.kt
+++ b/core/designsystem/src/main/java/com/yapp/core/designsystem/extension/Modifier.kt
@@ -8,12 +8,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 
 /**
  * Composable 에 clickable 을 설정해주는 [Modifier]
  *
  * @param rippleEnabled Ripple 여부 설정
  * @param rippleColor 표시된 Ripple Color
+ * @param rippleBounded Ripple 영역 초과 설정
+ * @param rippleRadius Ripple 영역
  * @param runIf clickable 이 발생하는 조건
  * @param singleClick 더블 클릭 방지 여부
  * @param onClick 컴포넌트가 클릭됐을 때 실행할 람다식
@@ -24,6 +27,8 @@ import androidx.compose.ui.graphics.Color
 fun Modifier.yappClickable(
     rippleEnabled: Boolean = true,
     rippleColor: Color? = null,
+    rippleBounded: Boolean = true,
+    rippleRadius: Dp = Dp.Unspecified,
     runIf: Boolean = true,
     singleClick: Boolean = true,
     onLongClick: (() -> Unit)? = null,
@@ -47,6 +52,8 @@ fun Modifier.yappClickable(
                 },
                 onLongClick = onLongClick,
                 indication = ripple(
+                    bounded = rippleBounded,
+                    radius = rippleRadius,
                     color = rippleColor ?: Color.Unspecified,
                 ).takeIf { rippleEnabled },
                 interactionSource = remember { MutableInteractionSource() },


### PR DESCRIPTION
## 💡 Issue
- Resolved: #이슈번호37

## 🌱 Key changes
<!--변경사항 적기-->
- HeaderActionbar Component 구현했습니다.
- yappClickable 확장 함수의 ripple 옵션을 더 자유롭게 구현할 수 있게 수정했습니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|![image](https://github.com/user-attachments/assets/f1e15fcc-8d0c-4467-a1ae-d3b6e6a2d31d)|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 디자인 시스템에 유연한 헤더 컴포넌트 추가
	- 클릭 가능한 요소의 리플 효과 커스터마이징 옵션 도입

- **개선 사항**
	- 헤더 컴포넌트에 좌측 아이콘, 우측 액션, 제목 옵션 추가
	- 리플 효과의 범위와 반경 설정 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->