### PR TITLE
Feature/#29 서비스 이용약관 팝업 기능

### DIFF
--- a/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
+++ b/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
@@ -9,7 +9,6 @@ import com.yapp.feature.login.navigation.loginNavGraph
 import com.yapp.feature.notice.navigation.noticeNavGraph
 import com.yapp.feature.signup.navigation.signupNavGraph
 
-
 @Composable
 fun YappNavHost(
     navigator: NavigatorState,
@@ -21,7 +20,7 @@ fun YappNavHost(
         modifier = modifier,
     ) {
         loginNavGraph(
-            onClickSignUp = { navigator.navigateSignUpScreen() }
+            navigateSignUp = { navigator.navigateSignUpScreen() }
         )
         signupNavGraph()
         homeNavGraph()

--- a/app/src/main/java/com/yapp/app/official/ui/Navigator.kt
+++ b/app/src/main/java/com/yapp/app/official/ui/Navigator.kt
@@ -10,10 +10,7 @@ import com.yapp.feature.home.navigation.navigateToHome
 import com.yapp.feature.login.navigation.LoginRoute
 import com.yapp.feature.login.navigation.navigateToLogin
 import com.yapp.feature.notice.navigation.navigateToNotice
-import com.yapp.feature.signup.navigation.SignUpRoute
 import com.yapp.feature.signup.navigation.navigateToSignUp
-import com.yapp.feature.signup.signup.SignUpRoute
-import com.yapp.feature.signup.signup.SignUpState
 
 
 @Composable
@@ -33,7 +30,7 @@ class NavigatorState(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = SignUpRoute
+    val startDestination = LoginRoute
 
     fun navigateLoginScreen() {
         navController.navigateToLogin()

--- a/app/src/main/java/com/yapp/app/official/ui/Navigator.kt
+++ b/app/src/main/java/com/yapp/app/official/ui/Navigator.kt
@@ -48,7 +48,7 @@ class NavigatorState(
         navController.navigateToNotice()
     }
 
-    private fun popBackStack() {
+    fun popBackStack() {
         navController.popBackStack()
     }
 }

--- a/core/designsystem/src/main/java/com/yapp/core/designsystem/component/input/nestedcheckbox/NestedCheckbox.kt
+++ b/core/designsystem/src/main/java/com/yapp/core/designsystem/component/input/nestedcheckbox/NestedCheckbox.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
@@ -37,7 +38,8 @@ fun YappNestedCheckboxBasic(
         modifier = modifier
             .yappClickable(
                 onClick = { onCheckedChange(!checked) },
-            )
+            ),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             modifier = Modifier.size(iconSize),

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
@@ -14,6 +14,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yapp.core.designsystem.theme.YappTheme
 import com.yapp.core.ui.component.YappBackground
+import com.yapp.core.ui.extension.collectWithLifecycle
 import com.yapp.feature.login.component.AgreementBottomDialog
 import com.yapp.feature.login.component.LoginDivider
 import com.yapp.feature.login.component.LoginInputSection
@@ -23,24 +24,27 @@ import com.yapp.feature.login.component.TopTitle
 
 @Composable
 internal fun LoginRoute(
-    navigateSignup: () -> Unit,
+    navigateToSignup: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val loginState by viewModel.store.uiState.collectAsStateWithLifecycle()
+    viewModel.store.sideEffects.collectWithLifecycle { effect ->
+        when (effect) {
+            LoginSideEffect.NavigateToSignUp -> navigateToSignup()
+        }
+    }
 
     LoginScreen(
         loginState = loginState,
-        onIntent = { viewModel.store.onIntent(it) },
-        navigateSignup
+        onIntent = { viewModel.store.onIntent(it) }
     )
 }
 
 @Composable
 fun LoginScreen(
     loginState: LoginState,
-    onIntent: (LoginIntent) -> Unit = {},
-    navigateSignup: () -> Unit,
+    onIntent: (LoginIntent) -> Unit = {}
 ) {
     YappBackground {
         Column(
@@ -65,13 +69,13 @@ fun LoginScreen(
         }
         if (loginState.showAgreementDialog) {
             AgreementBottomDialog(
-                { onIntent(LoginIntent.CloseAgreementDialog) },
-                loginState.agreement1,
-                loginState.agreement2,
-                { onIntent(LoginIntent.CheckAgreement1(it)) },
-                { onIntent(LoginIntent.CheckAgreement2(it)) },
-                loginState.enableNextButton,
-                { navigateSignup() }
+                onDismiss = { onIntent(LoginIntent.CloseAgreementDialog) },
+                agreement1 = loginState.agreement1,
+                agreement2 = loginState.agreement2,
+                onAgreement1Checked = { onIntent(LoginIntent.CheckAgreement1(it)) },
+                onAgreement2Checked = { onIntent(LoginIntent.CheckAgreement2(it)) },
+                enableNextButton = loginState.enableNextButton,
+                onClickNextButton = { onIntent(LoginIntent.ClickNextButton)}
             )
         }
     }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
@@ -57,10 +57,10 @@ fun LoginScreen(
             LoginInputSection(
                 email = loginState.email,
                 password = loginState.password,
-                onEmailChange = { onIntent(LoginIntent.EmailChanged(it)) },
-                onPasswordChange = { onIntent(LoginIntent.PasswordChanged(it)) },
+                onEmailChange = { onIntent(LoginIntent.ChangeEmail(it)) },
+                onPasswordChange = { onIntent(LoginIntent.ChangePassword(it)) },
                 buttonEnable = loginState.enableLoginButton,
-                onClickButton = { onIntent(LoginIntent.ClickLoginButton) }
+                onButtonClick = { onIntent(LoginIntent.ClickLoginButton) }
             )
             Spacer(Modifier.height(24.dp))
             LoginDivider()
@@ -70,12 +70,12 @@ fun LoginScreen(
         if (loginState.showAgreementDialog) {
             AgreementBottomDialog(
                 onDismiss = { onIntent(LoginIntent.CloseAgreementDialog) },
-                agreement1 = loginState.agreement1,
-                agreement2 = loginState.agreement2,
-                onAgreement1Checked = { onIntent(LoginIntent.CheckAgreement1(it)) },
-                onAgreement2Checked = { onIntent(LoginIntent.CheckAgreement2(it)) },
+                terms = loginState.terms,
+                personalPolicy = loginState.personalPolicy,
+                onTermsChecked = { onIntent(LoginIntent.CheckTerms(it)) },
+                onPersonalPolicyChecked = { onIntent(LoginIntent.CheckPersonalPolicy(it)) },
                 enableNextButton = loginState.enableNextButton,
-                onClickNextButton = { onIntent(LoginIntent.ClickNextButton)}
+                onNextButtonClick = { onIntent(LoginIntent.ClickNextButton)}
             )
         }
     }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
@@ -26,8 +26,8 @@ import com.yapp.feature.login.component.TopTitle
 
 
 @Composable
-internal fun LoginRouteScreen(
-    onClickSignUP: (String) -> Unit,
+internal fun LoginRoute(
+    onClickSignUp: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = hiltViewModel()
 ) {
@@ -45,39 +45,33 @@ internal fun LoginRouteScreen(
             .padding(horizontal = 20.dp),
         contentAlignment = Alignment.TopStart
     ) {
-        LoginContent(
+        LoginScreen(
             loginState = loginState,
-            onSignUpClick = {viewModel.store.onIntent(LoginIntent.ClickSignUpButton)},
-            onLoginClick = {viewModel.store.onIntent(LoginIntent.ClickLoginButton)},
-            onIDChange = { viewModel.store.onIntent(LoginIntent.InputID(it)) },
-            onPWChange = {viewModel.store.onIntent(LoginIntent.InputPW(it))}
+            onIntent = { viewModel.store.onIntent(it) },
         )
     }
 }
 
 @Composable
-fun LoginContent(
+fun LoginScreen(
     loginState: LoginState,
-    onSignUpClick: () -> Unit,
-    onLoginClick : () -> Unit,
-    onIDChange: (String) -> Unit,
-    onPWChange : (String) -> Unit,
+    onIntent: (LoginIntent) -> Unit = {}
 ) {
     Column {
         Spacer(Modifier.height(72.dp))
         TopTitle()
         LoginInputSection(
-            id = loginState.id,
-            pw = loginState.password,
-            onIDChange = onIDChange,
-            onPWChange = onPWChange,
-            isActive = loginState.isActivateLoginButton,
-            clickButton = onLoginClick
+            email = loginState.email,
+            password = loginState.password,
+            onEmailChange = {onIntent(LoginIntent.EmailChanged(it))},
+            onPasswordChange =  {onIntent(LoginIntent.PasswordChanged(it))},
+            buttonEnable = loginState.enableLoginButton,
+            onClickButton = { onIntent(LoginIntent.ClickLoginButton) }
         )
         Spacer(Modifier.height(24.dp))
         LoginDivider()
         Spacer(Modifier.height(32.dp))
-        LoginSignUpSection(onSignUpClick)
+        LoginSignUpSection { onIntent(LoginIntent.ClickSignUpButton) }
     }
 }
 
@@ -85,6 +79,6 @@ fun LoginContent(
 @Composable
 private fun LoginScreenPreview() {
     YappTheme {
-        LoginRouteScreen({})
+        LoginRoute({})
     }
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
@@ -1,8 +1,5 @@
-
 package com.yapp.feature.login
 
-import android.widget.Toast
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,15 +7,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yapp.core.designsystem.theme.YappTheme
-import com.yapp.core.ui.extension.collectWithLifecycle
+import com.yapp.core.ui.component.YappBackground
+import com.yapp.feature.login.component.AgreementBottomDialog
 import com.yapp.feature.login.component.LoginDivider
 import com.yapp.feature.login.component.LoginInputSection
 import com.yapp.feature.login.component.LoginSignUpSection
@@ -27,53 +23,60 @@ import com.yapp.feature.login.component.TopTitle
 
 @Composable
 internal fun LoginRoute(
-    onClickSignUp: (String) -> Unit,
+    navigateSignup: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: LoginViewModel = hiltViewModel()
+    viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val loginState by viewModel.store.uiState.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    viewModel.store.sideEffects.collectWithLifecycle { effect ->
-        when (effect) {
-            is LoginSideEffect.ShowSignUpDialog -> {}
-            is LoginSideEffect.ShowToast -> { Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show() }
-        }
-    }
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = 20.dp),
-        contentAlignment = Alignment.TopStart
-    ) {
-        LoginScreen(
-            loginState = loginState,
-            onIntent = { viewModel.store.onIntent(it) },
-        )
-    }
+
+    LoginScreen(
+        loginState = loginState,
+        onIntent = { viewModel.store.onIntent(it) },
+        navigateSignup
+    )
 }
 
 @Composable
 fun LoginScreen(
     loginState: LoginState,
-    onIntent: (LoginIntent) -> Unit = {}
+    onIntent: (LoginIntent) -> Unit = {},
+    navigateSignup: () -> Unit,
 ) {
-    Column {
-        Spacer(Modifier.height(72.dp))
-        TopTitle()
-        LoginInputSection(
-            email = loginState.email,
-            password = loginState.password,
-            onEmailChange = {onIntent(LoginIntent.EmailChanged(it))},
-            onPasswordChange =  {onIntent(LoginIntent.PasswordChanged(it))},
-            buttonEnable = loginState.enableLoginButton,
-            onClickButton = { onIntent(LoginIntent.ClickLoginButton) }
-        )
-        Spacer(Modifier.height(24.dp))
-        LoginDivider()
-        Spacer(Modifier.height(32.dp))
-        LoginSignUpSection { onIntent(LoginIntent.ClickSignUpButton) }
+    YappBackground {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp)
+        ) {
+            Spacer(Modifier.height(72.dp))
+            TopTitle()
+            LoginInputSection(
+                email = loginState.email,
+                password = loginState.password,
+                onEmailChange = { onIntent(LoginIntent.EmailChanged(it)) },
+                onPasswordChange = { onIntent(LoginIntent.PasswordChanged(it)) },
+                buttonEnable = loginState.enableLoginButton,
+                onClickButton = { onIntent(LoginIntent.ClickLoginButton) }
+            )
+            Spacer(Modifier.height(24.dp))
+            LoginDivider()
+            Spacer(Modifier.height(32.dp))
+            LoginSignUpSection { onIntent(LoginIntent.ClickSignUpButton) }
+        }
+        if (loginState.showAgreementDialog) {
+            AgreementBottomDialog(
+                { onIntent(LoginIntent.CloseAgreementDialog) },
+                loginState.agreement1,
+                loginState.agreement2,
+                { onIntent(LoginIntent.CheckAgreement1(it)) },
+                { onIntent(LoginIntent.CheckAgreement2(it)) },
+                loginState.enableNextButton,
+                { navigateSignup() }
+            )
+        }
     }
 }
+
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginState.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginState.kt
@@ -2,18 +2,17 @@ package com.yapp.feature.login
 
 
 data class LoginState(
-    val id: String = "",
+    val email: String = "",
     val password: String = "",
-    val idFailDescription : String? = null,
-    val pwFailDescription : String? = null,
-    val isPWVisible: Boolean = false, // 비밀번호 표시 여부
+    val emailErrorDescription : String? = null,
+    val passwordErrorDescription : String? = null
 ){
-    val isActivateLoginButton : Boolean = id.isNotEmpty() && password.isNotEmpty()
+    val enableLoginButton : Boolean = email.isNotEmpty() && password.isNotEmpty()
 }
 
 sealed interface LoginIntent {
-    data class InputID (val id : String) : LoginIntent
-    data class InputPW ( val pw : String ) : LoginIntent
+    data class EmailChanged (val email : String) : LoginIntent
+    data class PasswordChanged (val password : String ) : LoginIntent
     data object ClickLoginButton : LoginIntent
     data object ClickSignUpButton : LoginIntent
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginState.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginState.kt
@@ -7,21 +7,21 @@ data class LoginState(
     val emailErrorDescription: String? = null,
     val passwordErrorDescription: String? = null,
     val showAgreementDialog: Boolean = false,
-    val agreement1: Boolean = false,
-    val agreement2: Boolean = false,
+    val terms: Boolean = false,
+    val personalPolicy: Boolean = false,
 ) {
     val enableLoginButton: Boolean = email.isNotEmpty() && password.isNotEmpty()
-    val enableNextButton: Boolean = agreement1 && agreement2
+    val enableNextButton: Boolean = terms && personalPolicy
 }
 
 sealed interface LoginIntent {
-    data class EmailChanged(val email: String) : LoginIntent
-    data class PasswordChanged(val password: String) : LoginIntent
+    data class ChangeEmail(val email: String) : LoginIntent
+    data class ChangePassword(val password: String) : LoginIntent
     data object ClickLoginButton : LoginIntent
     data object ClickSignUpButton : LoginIntent
     data object CloseAgreementDialog : LoginIntent
-    data class CheckAgreement1(val checked: Boolean) : LoginIntent
-    data class CheckAgreement2(val checked: Boolean) : LoginIntent
+    data class CheckTerms(val checked: Boolean) : LoginIntent
+    data class CheckPersonalPolicy(val checked: Boolean) : LoginIntent
     data object ClickNextButton : LoginIntent
 }
 

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginState.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginState.kt
@@ -4,20 +4,22 @@ package com.yapp.feature.login
 data class LoginState(
     val email: String = "",
     val password: String = "",
-    val emailErrorDescription : String? = null,
-    val passwordErrorDescription : String? = null
-){
-    val enableLoginButton : Boolean = email.isNotEmpty() && password.isNotEmpty()
+    val emailErrorDescription: String? = null,
+    val passwordErrorDescription: String? = null,
+    val showAgreementDialog: Boolean = false,
+    val agreement1: Boolean = false,
+    val agreement2: Boolean = false,
+) {
+    val enableLoginButton: Boolean = email.isNotEmpty() && password.isNotEmpty()
+    val enableNextButton: Boolean = agreement1 && agreement2
 }
 
 sealed interface LoginIntent {
-    data class EmailChanged (val email : String) : LoginIntent
-    data class PasswordChanged (val password : String ) : LoginIntent
+    data class EmailChanged(val email: String) : LoginIntent
+    data class PasswordChanged(val password: String) : LoginIntent
     data object ClickLoginButton : LoginIntent
     data object ClickSignUpButton : LoginIntent
-}
-
-sealed interface LoginSideEffect {
-    data object ShowSignUpDialog : LoginSideEffect
-    data class ShowToast(val message: String) : LoginSideEffect
+    data object CloseAgreementDialog : LoginIntent
+    data class CheckAgreement1(val checked: Boolean) : LoginIntent
+    data class CheckAgreement2(val checked: Boolean) : LoginIntent
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginState.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginState.kt
@@ -22,4 +22,9 @@ sealed interface LoginIntent {
     data object CloseAgreementDialog : LoginIntent
     data class CheckAgreement1(val checked: Boolean) : LoginIntent
     data class CheckAgreement2(val checked: Boolean) : LoginIntent
+    data object ClickNextButton : LoginIntent
+}
+
+sealed interface LoginSideEffect {
+    data object NavigateToSignUp : LoginSideEffect
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
@@ -15,11 +15,11 @@ class LoginViewModel @Inject constructor() : ViewModel() {
                 when (intent) {
                     is LoginIntent.ClickLoginButton -> {}
                     is LoginIntent.ClickSignUpButton -> reduce { copy(showAgreementDialog = true) }
-                    is LoginIntent.EmailChanged -> reduce { copy(email = intent.email) }
-                    is LoginIntent.PasswordChanged -> reduce { copy(password = intent.password) }
+                    is LoginIntent.ChangeEmail -> reduce { copy(email = intent.email) }
+                    is LoginIntent.ChangePassword -> reduce { copy(password = intent.password) }
                     is LoginIntent.CloseAgreementDialog -> reduce { copy(showAgreementDialog = false) }
-                    is LoginIntent.CheckAgreement1 -> reduce { copy(agreement1 = intent.checked) }
-                    is LoginIntent.CheckAgreement2 -> reduce { copy(agreement2 = intent.checked) }
+                    is LoginIntent.CheckTerms -> reduce { copy(terms = intent.checked) }
+                    is LoginIntent.CheckPersonalPolicy -> reduce { copy(personalPolicy = intent.checked) }
                     is LoginIntent.ClickNextButton -> postSideEffect(LoginSideEffect.NavigateToSignUp)
                 }
             }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
@@ -15,8 +15,8 @@ class LoginViewModel @Inject constructor() : ViewModel() {
                 when (intent) {
                     is LoginIntent.ClickLoginButton -> {}
                     is LoginIntent.ClickSignUpButton -> { postSideEffect(LoginSideEffect.ShowToast("회원가입 버튼 클릭")) }
-                    is LoginIntent.InputID -> reduce { copy(id = intent.id) }
-                    is LoginIntent.InputPW -> reduce { copy(password = intent.pw )}
+                    is LoginIntent.EmailChanged -> reduce { copy(email = intent.email) }
+                    is LoginIntent.PasswordChanged -> reduce { copy(password = intent.password )}
                 }
             }
         )

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
@@ -8,10 +8,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor() : ViewModel() {
-    val store: MviIntentStore<LoginState, LoginIntent, Nothing> =
+    val store: MviIntentStore<LoginState, LoginIntent, LoginSideEffect> =
         mviIntentStore(
             initialState = LoginState(),
-            onIntent = { intent, _, reduce, _ ->
+            onIntent = { intent, _, reduce, postSideEffect  ->
                 when (intent) {
                     is LoginIntent.ClickLoginButton -> {}
                     is LoginIntent.ClickSignUpButton -> reduce { copy(showAgreementDialog = true) }
@@ -20,6 +20,7 @@ class LoginViewModel @Inject constructor() : ViewModel() {
                     is LoginIntent.CloseAgreementDialog -> reduce { copy(showAgreementDialog = false) }
                     is LoginIntent.CheckAgreement1 -> reduce { copy(agreement1 = intent.checked) }
                     is LoginIntent.CheckAgreement2 -> reduce { copy(agreement2 = intent.checked) }
+                    is LoginIntent.ClickNextButton -> postSideEffect(LoginSideEffect.NavigateToSignUp)
                 }
             }
         )

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
@@ -8,15 +8,18 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor() : ViewModel() {
-    val store: MviIntentStore<LoginState, LoginIntent, LoginSideEffect> =
+    val store: MviIntentStore<LoginState, LoginIntent, Nothing> =
         mviIntentStore(
             initialState = LoginState(),
-            onIntent = { intent, state, reduce, postSideEffect ->
+            onIntent = { intent, _, reduce, _ ->
                 when (intent) {
                     is LoginIntent.ClickLoginButton -> {}
-                    is LoginIntent.ClickSignUpButton -> { postSideEffect(LoginSideEffect.ShowToast("회원가입 버튼 클릭")) }
+                    is LoginIntent.ClickSignUpButton -> reduce { copy(showAgreementDialog = true) }
                     is LoginIntent.EmailChanged -> reduce { copy(email = intent.email) }
-                    is LoginIntent.PasswordChanged -> reduce { copy(password = intent.password )}
+                    is LoginIntent.PasswordChanged -> reduce { copy(password = intent.password) }
+                    is LoginIntent.CloseAgreementDialog -> reduce { copy(showAgreementDialog = false) }
+                    is LoginIntent.CheckAgreement1 -> reduce { copy(agreement1 = intent.checked) }
+                    is LoginIntent.CheckAgreement2 -> reduce { copy(agreement2 = intent.checked) }
                 }
             }
         )

--- a/feature/login/src/main/java/com/yapp/feature/login/component/AgreementBottomDialog.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/component/AgreementBottomDialog.kt
@@ -1,0 +1,118 @@
+package com.yapp.feature.login.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.yapp.core.designsystem.component.button.solid.YappSolidPrimaryButtonXLarge
+import com.yapp.core.designsystem.component.button.text.YappTextAssistiveButtonSmall
+import com.yapp.core.designsystem.component.input.nestedcheckbox.YappNestedCheckboxNormal
+import com.yapp.core.designsystem.theme.YappTheme
+import com.yapp.core.ui.component.BottomDialog
+import com.yapp.feature.login.R
+
+
+@Composable
+fun AgreementBottomDialog(
+    onDismiss: () -> Unit,
+    agreement1: Boolean,
+    agreement2: Boolean,
+    onAgreement1Checked: (Boolean) -> Unit,
+    onAgreement2Checked: (Boolean) -> Unit,
+    enableNextButton: Boolean,
+    onClickNextButton: () -> Unit,
+) {
+    BottomDialog(
+        onDismiss = onDismiss
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = stringResource(R.string.agreement_bottom_dialog_title),
+                style = YappTheme.typography.headline1Bold,
+                color = YappTheme.colorScheme.labelNormal
+            )
+            Spacer(Modifier.height(24.dp))
+            AgreementContent(
+                text = stringResource(R.string.agreement_bottom_dialog_item1),
+                checked = agreement1,
+                onCheckedChange = { onAgreement1Checked(it) }
+            )
+            AgreementContent(
+                text = stringResource(R.string.agreement_bottom_dialog_item2),
+                checked = agreement2,
+                onCheckedChange = { onAgreement2Checked(it) }
+            )
+            Spacer(Modifier.height(24.dp))
+            YappSolidPrimaryButtonXLarge(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.agreement_bottom_dialog_button_next),
+                enable = enableNextButton,
+                onClick = { onClickNextButton() }
+            )
+        }
+    }
+}
+
+@Composable
+fun AgreementContent(
+    text: String,
+    modifier: Modifier = Modifier,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        YappNestedCheckboxNormal(
+            text = text,
+            checked = checked,
+            onCheckedChange = onCheckedChange
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(
+            text = stringResource(R.string.agreement_bottom_dialog_text_essential),
+            style = YappTheme.typography.body2NormalRegular,
+            color = YappTheme.colorScheme.primaryNormal,
+        )
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.CenterEnd
+        ) {
+            YappTextAssistiveButtonSmall(
+                text = stringResource(R.string.agreement_bottom_dialog_button_detail),
+                onClick = {}
+            )
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun LoginScreenPreview() {
+    YappTheme {
+        AgreementBottomDialog(
+            {},
+            agreement1 = true,
+            agreement2 = false,
+            onAgreement1Checked = {},
+            onAgreement2Checked = {},
+            enableNextButton = false,
+            onClickNextButton = {}
+        )
+    }
+}

--- a/feature/login/src/main/java/com/yapp/feature/login/component/AgreementBottomDialog.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/component/AgreementBottomDialog.kt
@@ -103,7 +103,7 @@ fun AgreementContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun LoginScreenPreview() {
+private fun AgreementBottomDialogPreview() {
     YappTheme {
         AgreementBottomDialog(
             {},

--- a/feature/login/src/main/java/com/yapp/feature/login/component/AgreementBottomDialog.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/component/AgreementBottomDialog.kt
@@ -26,12 +26,12 @@ import com.yapp.feature.login.R
 @Composable
 fun AgreementBottomDialog(
     onDismiss: () -> Unit,
-    agreement1: Boolean,
-    agreement2: Boolean,
-    onAgreement1Checked: (Boolean) -> Unit,
-    onAgreement2Checked: (Boolean) -> Unit,
+    terms: Boolean,
+    personalPolicy: Boolean,
+    onTermsChecked: (Boolean) -> Unit,
+    onPersonalPolicyChecked: (Boolean) -> Unit,
     enableNextButton: Boolean,
-    onClickNextButton: () -> Unit,
+    onNextButtonClick: () -> Unit,
 ) {
     BottomDialog(
         onDismiss = onDismiss
@@ -44,21 +44,21 @@ fun AgreementBottomDialog(
             )
             Spacer(Modifier.height(24.dp))
             AgreementContent(
-                text = stringResource(R.string.agreement_bottom_dialog_item1),
-                checked = agreement1,
-                onCheckedChange = { onAgreement1Checked(it) }
+                text = stringResource(R.string.agreement_bottom_dialog_terms),
+                checked = terms,
+                onCheckedChange = { onTermsChecked(it) }
             )
             AgreementContent(
-                text = stringResource(R.string.agreement_bottom_dialog_item2),
-                checked = agreement2,
-                onCheckedChange = { onAgreement2Checked(it) }
+                text = stringResource(R.string.agreement_bottom_dialog_personal_policy),
+                checked = personalPolicy,
+                onCheckedChange = { onPersonalPolicyChecked(it) }
             )
             Spacer(Modifier.height(24.dp))
             YappSolidPrimaryButtonXLarge(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(R.string.agreement_bottom_dialog_button_next),
                 enable = enableNextButton,
-                onClick = { onClickNextButton() }
+                onClick = { onNextButtonClick() }
             )
         }
     }
@@ -107,12 +107,12 @@ private fun LoginScreenPreview() {
     YappTheme {
         AgreementBottomDialog(
             {},
-            agreement1 = true,
-            agreement2 = false,
-            onAgreement1Checked = {},
-            onAgreement2Checked = {},
+            terms = true,
+            personalPolicy = false,
+            onTermsChecked = {},
+            onPersonalPolicyChecked = {},
             enableNextButton = false,
-            onClickNextButton = {}
+            onNextButtonClick = {}
         )
     }
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/component/LoginDivider.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/component/LoginDivider.kt
@@ -1,6 +1,5 @@
 package com.yapp.feature.login.component
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -45,8 +44,6 @@ fun LoginDivider(){
 @Composable
 private fun LoginScreenPreview() {
     YappTheme {
-        Column {
-            LoginDivider()
-        }
+        LoginDivider()
     }
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/component/LoginInputSection.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/component/LoginInputSection.kt
@@ -17,31 +17,31 @@ import com.yapp.feature.login.R
 
 @Composable
 fun LoginInputSection(
-    id : String,
-    pw : String,
-    onIDChange: (String) -> Unit,
-    onPWChange: (String) -> Unit,
-    isActive : Boolean,
-    clickButton : () -> Unit
+    email : String,
+    password : String,
+    onEmailChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    buttonEnable : Boolean,
+    onClickButton : () -> Unit
 ) {
     YappInputTextLarge(
-        value = id,
-        onValueChange = onIDChange,
+        value = email,
+        onValueChange = onEmailChange,
         placeholder = stringResource(R.string.login_placeholder_email),
     )
     Spacer(Modifier.height(16.dp))
     PasswordInputTextLarge(
         label = stringResource(R.string.login_title_pw),
-        password = pw,
-        onPasswordChange = onPWChange,
+        password = password,
+        onPasswordChange = onPasswordChange,
         placeholder = stringResource(R.string.login_placeholder_pw)
     )
     Spacer(Modifier.height(24.dp))
     YappSolidPrimaryButtonXLarge(
         modifier = Modifier.fillMaxWidth(),
         text = stringResource(R.string.login_btn),
-        enable = (isActive),
-        onClick = clickButton
+        enable = (buttonEnable),
+        onClick = onClickButton
     )
 }
 

--- a/feature/login/src/main/java/com/yapp/feature/login/component/LoginInputSection.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/component/LoginInputSection.kt
@@ -22,7 +22,7 @@ fun LoginInputSection(
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
     buttonEnable : Boolean,
-    onClickButton : () -> Unit
+    onButtonClick : () -> Unit
 ) {
     YappInputTextLarge(
         value = email,
@@ -41,7 +41,7 @@ fun LoginInputSection(
         modifier = Modifier.fillMaxWidth(),
         text = stringResource(R.string.login_btn),
         enable = (buttonEnable),
-        onClick = onClickButton
+        onClick = onButtonClick
     )
 }
 

--- a/feature/login/src/main/java/com/yapp/feature/login/component/LoginSignUpSection.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/component/LoginSignUpSection.kt
@@ -20,7 +20,7 @@ import com.yapp.feature.login.R
 @Stable
 @Composable
 fun LoginSignUpSection(
-    onClickSignUp : () -> Unit
+    onSignUpClick : () -> Unit
 ){
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -36,7 +36,7 @@ fun LoginSignUpSection(
             text = stringResource(R.string.login_btn_signup),
             contentPaddings = PaddingValues(0.dp),
             enable = true,
-            onClick = onClickSignUp
+            onClick = onSignUpClick
         )
     }
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/component/LoginSignUpSection.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/component/LoginSignUpSection.kt
@@ -20,7 +20,7 @@ import com.yapp.feature.login.R
 @Stable
 @Composable
 fun LoginSignUpSection(
-    clickSignUpButton : () -> Unit
+    onClickSignUp : () -> Unit
 ){
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -36,7 +36,7 @@ fun LoginSignUpSection(
             text = stringResource(R.string.login_btn_signup),
             contentPaddings = PaddingValues(0.dp),
             enable = true,
-            onClick = clickSignUpButton
+            onClick = onClickSignUp
         )
     }
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/navigation/LoginNavigation.kt
@@ -4,7 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.yapp.feature.login.LoginRouteScreen
+import com.yapp.feature.login.LoginRoute
 import kotlinx.serialization.Serializable
 
 @Serializable data object LoginRoute
@@ -15,6 +15,6 @@ fun NavGraphBuilder.loginNavGraph(
     onClickSignUp: (String) -> Unit,
 ){
     composable<LoginRoute> {
-        LoginRouteScreen(onClickSignUp)
+        LoginRoute(onClickSignUp)
     }
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/navigation/LoginNavigation.kt
@@ -12,9 +12,9 @@ import kotlinx.serialization.Serializable
 fun NavController.navigateToLogin(navOptions: NavOptions? = null) { navigate(LoginRoute, navOptions) }
 
 fun NavGraphBuilder.loginNavGraph(
-    onClickSignUp: (String) -> Unit,
+    navigateSignUp: () -> Unit,
 ){
     composable<LoginRoute> {
-        LoginRoute(onClickSignUp)
+        LoginRoute(navigateSignUp)
     }
 }

--- a/feature/login/src/main/res/values/strings.xml
+++ b/feature/login/src/main/res/values/strings.xml
@@ -9,4 +9,12 @@
     <string name="login_title_signup">아직 회원이 아니신가요?</string>
     <string name="login_btn_signup">회원가입</string>
     <string name="login_divider">또는</string>
+
+    
+    <string name="agreement_bottom_dialog_title">서비스 이용약관</string>
+    <string name="agreement_bottom_dialog_item1">서비스 이용약관에 동의</string>
+    <string name="agreement_bottom_dialog_item2">개인정보 수집 및 이용 동의</string>
+    <string name="agreement_bottom_dialog_button_next">다음</string>
+    <string name="agreement_bottom_dialog_text_essential">(필수)</string>
+    <string name="agreement_bottom_dialog_button_detail">보기</string>
 </resources>

--- a/feature/login/src/main/res/values/strings.xml
+++ b/feature/login/src/main/res/values/strings.xml
@@ -12,8 +12,8 @@
 
     
     <string name="agreement_bottom_dialog_title">서비스 이용약관</string>
-    <string name="agreement_bottom_dialog_item1">서비스 이용약관에 동의</string>
-    <string name="agreement_bottom_dialog_item2">개인정보 수집 및 이용 동의</string>
+    <string name="agreement_bottom_dialog_terms">서비스 이용약관에 동의</string>
+    <string name="agreement_bottom_dialog_personal_policy">개인정보 수집 및 이용 동의</string>
     <string name="agreement_bottom_dialog_button_next">다음</string>
     <string name="agreement_bottom_dialog_text_essential">(필수)</string>
     <string name="agreement_bottom_dialog_button_detail">보기</string>


### PR DESCRIPTION
## 💡 Issue
- Resolved: #29 

## 🌱 Key changes
- BottomDialog 노출 후 회원가입으로 이동

## ✅ To Reviewers
- 이전 PR에서 리뷰 달아주신 네이밍 전체적으로 수정하였습니다  + Intent 변수명 통일
- dialog 에서 보기 클릭시 노션 페이지로 이동 하는 부분 추가 구현 해야합니다 !

## 📸 스크린샷
|스크린샷|
|:--:|
|![스크린샷 2025-01-28 오후 6 44 36](https://github.com/user-attachments/assets/8bd144ab-b098-4e84-b1d0-4ab38b10baf8)|
![스크린샷 2025-01-28 오후 6 44 26](https://github.com/user-attachments/assets/83b16c8c-2330-4775-bd36-b5326f885f26)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 로그인 화면에 서비스 이용약관 및 개인정보 수집 동의 다이얼로그 추가
  - 이메일 기반 로그인 프로세스 개선

- **사용자 경험 개선**
  - 로그인 입력 필드 및 버튼 명칭 최적화
  - 로그인 화면의 레이아웃 및 탐색 흐름 개선

- **UI 변경**
  - 바텀 다이얼로그 시스템 창 상호작용 조정
  - 체크박스 및 입력 컴포넌트 정렬 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->