### PR TITLE
Feature/#66 setting logic (로그아웃, 이용약관, 다이얼로그 노출)

### DIFF
--- a/app/src/main/java/com/yapp/app/official/ui/Navigator.kt
+++ b/app/src/main/java/com/yapp/app/official/ui/Navigator.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.yapp.feature.home.navigation.HomeRoute
 import com.yapp.feature.home.navigation.navigateToHome
 import com.yapp.feature.login.navigation.LoginRoute
 import com.yapp.feature.login.navigation.navigateToLogin
@@ -30,7 +31,7 @@ class NavigatorState(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = LoginRoute
+    val startDestination = HomeRoute
 
     fun navigateLoginScreen() {
         navController.navigateToLogin()

--- a/core/data-api/src/main/java/com/yapp/data_api/MyClass.kt
+++ b/core/data-api/src/main/java/com/yapp/data_api/MyClass.kt
@@ -1,4 +1,0 @@
-package com.yapp.data_api
-
-class MyClass  {
-}

--- a/core/data-api/src/main/java/com/yapp/dataapi/AuthorizedUserRepository.kt
+++ b/core/data-api/src/main/java/com/yapp/dataapi/AuthorizedUserRepository.kt
@@ -1,0 +1,5 @@
+package com.yapp.dataapi
+
+interface AuthorizedUserRepository {
+    suspend fun clearTokens()
+}

--- a/core/data-api/src/main/java/com/yapp/dataapi/UnAuthorizedUserRepository.kt
+++ b/core/data-api/src/main/java/com/yapp/dataapi/UnAuthorizedUserRepository.kt
@@ -1,4 +1,4 @@
-package com.yapp.data_api
+package com.yapp.dataapi
 
 import com.yapp.model.SignUpInfo
 import com.yapp.model.SignUpResult

--- a/core/data/src/main/java/com/yapp/core/data/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/yapp/core/data/data/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.yapp.core.data.data.di
 
+import com.yapp.core.data.data.repository.AuthorizedUserRepositoryImpl
 import com.yapp.core.data.data.repository.UnAuthorizedUserRepositoryImpl
-import com.yapp.data_api.UnAuthorizedUserRepository
+import com.yapp.dataapi.AuthorizedUserRepository
+import com.yapp.dataapi.UnAuthorizedUserRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,6 +15,11 @@ internal abstract class RepositoryModule {
 
     @Binds
     abstract fun bindUnAuthorizedUserRepositoryImpl(
-        unAuthorizedUserRepositoryImpl: UnAuthorizedUserRepositoryImpl,
+        repositoryImpl: UnAuthorizedUserRepositoryImpl,
     ): UnAuthorizedUserRepository
+
+    @Binds
+    abstract fun bindAuthorizedUserRepositoryImpl(
+        repositoryImpl: AuthorizedUserRepositoryImpl,
+    ): AuthorizedUserRepository
 }

--- a/core/data/src/main/java/com/yapp/core/data/data/repository/AuthorizedUserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/yapp/core/data/data/repository/AuthorizedUserRepositoryImpl.kt
@@ -4,27 +4,18 @@ import com.yapp.core.data.local.SecurityPreferences
 import com.yapp.core.data.remote.api.UnAuthorizedUserApi
 import com.yapp.core.data.remote.model.request.toData
 import com.yapp.core.data.remote.model.response.toModel
+import com.yapp.dataapi.AuthorizedUserRepository
 import com.yapp.dataapi.UnAuthorizedUserRepository
 import com.yapp.model.SignUpInfo
 import com.yapp.model.SignUpResult
 import javax.inject.Inject
 import kotlin.jvm.optionals.getOrNull
 
-internal class UnAuthorizedUserRepositoryImpl @Inject constructor(
-    private val api: UnAuthorizedUserApi,
+internal class AuthorizedUserRepositoryImpl @Inject constructor(
     private val securityPreferences: SecurityPreferences,
-): UnAuthorizedUserRepository {
+): AuthorizedUserRepository {
 
-    override suspend fun signUp(request: SignUpInfo): SignUpResult {
-        val response = api.signUp(
-            request.toData()
-        )
-
-        response.getOrNull()?.let {
-            securityPreferences.setAccessToken(it.accessToken)
-            securityPreferences.setRefreshToken(it.refreshToken)
-        }
-
-        return response.toModel()
+    override suspend fun clearTokens() {
+        securityPreferences.clearAll()
     }
 }

--- a/core/domain/src/main/java/com/yapp/domain/LogoutUseCase.kt
+++ b/core/domain/src/main/java/com/yapp/domain/LogoutUseCase.kt
@@ -1,0 +1,12 @@
+package com.yapp.domain
+
+import com.yapp.dataapi.AuthorizedUserRepository
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val authorizedUserRepository: AuthorizedUserRepository,
+) {
+    suspend operator fun invoke() = runCatchingIgnoreCancelled {
+        authorizedUserRepository.clearTokens()
+    }
+}

--- a/core/domain/src/main/java/com/yapp/domain/SignUpUseCase.kt
+++ b/core/domain/src/main/java/com/yapp/domain/SignUpUseCase.kt
@@ -1,8 +1,7 @@
 package com.yapp.domain
 
-import com.yapp.data_api.UnAuthorizedUserRepository
+import com.yapp.dataapi.UnAuthorizedUserRepository
 import com.yapp.model.SignUpInfo
-import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 class SignUpUseCase @Inject constructor(

--- a/core/ui/src/main/java/com/yapp/core/ui/constant/Url.kt
+++ b/core/ui/src/main/java/com/yapp/core/ui/constant/Url.kt
@@ -1,0 +1,6 @@
+package com.yapp.core.ui.constant
+
+object Url {
+    const val TERMS = "https://yapp-workspace.notion.site/48f4eb2ffdd94740979e8a3b37ca260d"
+    const val PRIVACY_POLICY = "https://yapp-workspace.notion.site/fc24f8ba29c34f9eb30eb945c621c1ca"
+}

--- a/feature/home/src/main/java/com/yapp/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/navigation/HomeNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.yapp.feature.home.HomeScreen
+import com.yapp.feature.home.setting.SettingRoute
 import kotlinx.serialization.Serializable
 
 @Serializable data object HomeRoute
@@ -13,6 +14,6 @@ fun NavController.navigateToHome(navOptions: NavOptions? = null) { navigate(Home
 
 fun NavGraphBuilder.homeNavGraph(){
     composable<HomeRoute> {
-        HomeScreen()
+        SettingRoute()
     }
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/setting/SettingContract.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/setting/SettingContract.kt
@@ -2,7 +2,8 @@ package com.yapp.feature.home.setting
 
 data class SettingState(
     val isNotificationEnabled: Boolean = false,
-    val errorMessage: String? = null
+    val showLogoutDialog: Boolean = false,
+    val showDeleteAccountDialog: Boolean = false,
 )
 
 sealed interface SettingIntent {
@@ -13,6 +14,12 @@ sealed interface SettingIntent {
     data object ClickTermsItem : SettingIntent
     data object ClickInquiryItem : SettingIntent
     data object ClickDeleteAccountButton : SettingIntent
+    data object DismissLogoutDialog : SettingIntent
+    data object ClickLogoutDialogActionButton : SettingIntent
+    data object ClickLogoutDialogRecommendActionButton : SettingIntent
+    data object DismissDeleteAccountDialog : SettingIntent
+    data object ClickDeleteAccountDialogActionButton : SettingIntent
+    data object ClickDeleteAccountDialogRecommendActionButton : SettingIntent
 }
 
 sealed interface SettingSideEffect {

--- a/feature/home/src/main/java/com/yapp/feature/home/setting/SettingContract.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/setting/SettingContract.kt
@@ -27,4 +27,5 @@ sealed interface SettingSideEffect {
     data object OpenPrivacyPolicy : SettingSideEffect
     data object OpenTerms : SettingSideEffect
     data object OpenInquiry : SettingSideEffect
+    data object NavigateToLogin : SettingSideEffect
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/setting/SettingScreen.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/setting/SettingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.yapp.core.designsystem.component.alert.YappAlertDialog
 import com.yapp.core.designsystem.component.button.outlined.YappOutlinedSecondaryButtonXLarge
 import com.yapp.core.designsystem.component.control.switches.YappSwitchMedium
 import com.yapp.core.designsystem.component.header.YappHeaderActionbarExpanded
@@ -172,6 +173,29 @@ fun SettingScreen(
             )
 
             Spacer(Modifier.height(16.dp))
+        }
+
+        if (uiState.showLogoutDialog) {
+            YappAlertDialog(
+                title = stringResource(R.string.logout_dialog_title),
+                actionButtonText = stringResource(R.string.logout_dialog_action_button),
+                recommendActionButtonText = stringResource(R.string.logout_dialog_recommend_action_button),
+                onDismissRequest = { onIntent(SettingIntent.DismissLogoutDialog) },
+                onActionButtonClick = { onIntent(SettingIntent.ClickLogoutDialogActionButton) },
+                onRecommendActionButtonClick = { onIntent(SettingIntent.ClickLogoutDialogRecommendActionButton) },
+            )
+        }
+
+        if (uiState.showDeleteAccountDialog) {
+            YappAlertDialog(
+                title = stringResource(R.string.delete_account_dialog_title),
+                body = stringResource(R.string.delete_account_dialog_body),
+                actionButtonText = stringResource(R.string.delete_account_dialog_action_button),
+                recommendActionButtonText = stringResource(R.string.delete_account_dialog_recommend_action_button),
+                onDismissRequest = { onIntent(SettingIntent.DismissDeleteAccountDialog) },
+                onActionButtonClick = { onIntent(SettingIntent.ClickDeleteAccountDialogActionButton) },
+                onRecommendActionButtonClick = { onIntent(SettingIntent.ClickDeleteAccountDialogRecommendActionButton) },
+            )
         }
     }
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/setting/SettingScreen.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/setting/SettingScreen.kt
@@ -1,5 +1,7 @@
 package com.yapp.feature.home.setting
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,6 +25,7 @@ import com.yapp.core.designsystem.component.control.switches.YappSwitchMedium
 import com.yapp.core.designsystem.component.header.YappHeaderActionbarExpanded
 import com.yapp.core.designsystem.theme.YappTheme
 import com.yapp.core.ui.component.YappBackground
+import com.yapp.core.ui.constant.Url
 import com.yapp.core.ui.extension.borderBottom
 import com.yapp.core.ui.extension.collectWithLifecycle
 import com.yapp.feature.home.R
@@ -33,14 +37,24 @@ fun SettingRoute(
     viewModel: SettingViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.store.uiState.collectAsStateWithLifecycle()
+
+    val context = LocalContext.current
+
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             SettingSideEffect.NavigateBack -> {
             }
+
             SettingSideEffect.OpenPrivacyPolicy -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(Url.PRIVACY_POLICY))
+                context.startActivity(intent)
             }
+
             SettingSideEffect.OpenTerms -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(Url.TERMS))
+                context.startActivity(intent)
             }
+
             SettingSideEffect.OpenInquiry -> {
             }
         }

--- a/feature/home/src/main/java/com/yapp/feature/home/setting/SettingScreen.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/setting/SettingScreen.kt
@@ -57,6 +57,9 @@ fun SettingRoute(
 
             SettingSideEffect.OpenInquiry -> {
             }
+
+            SettingSideEffect.NavigateToLogin -> {
+            }
         }
     }
 

--- a/feature/home/src/main/java/com/yapp/feature/home/setting/SettingViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/setting/SettingViewModel.kt
@@ -26,6 +26,7 @@ class SettingViewModel @Inject constructor() : ViewModel() {
                 reduce { copy(isNotificationEnabled = intent.enabled) }
             }
             SettingIntent.ClickLogoutButton -> {
+                reduce { copy(showLogoutDialog = true) }
             }
             SettingIntent.ClickBackButton -> {
                 postSideEffect(SettingSideEffect.NavigateBack)
@@ -40,7 +41,21 @@ class SettingViewModel @Inject constructor() : ViewModel() {
                 postSideEffect(SettingSideEffect.OpenInquiry)
             }
             SettingIntent.ClickDeleteAccountButton -> {
+                reduce { copy(showDeleteAccountDialog = true) }
             }
+
+            SettingIntent.DismissDeleteAccountDialog,
+            SettingIntent.ClickDeleteAccountDialogActionButton -> {
+                reduce { copy(showDeleteAccountDialog = false) }
+            }
+
+            SettingIntent.DismissLogoutDialog,
+            SettingIntent.ClickLogoutDialogActionButton -> {
+                reduce { copy(showLogoutDialog = false) }
+            }
+
+            SettingIntent.ClickDeleteAccountDialogRecommendActionButton -> TODO()
+            SettingIntent.ClickLogoutDialogRecommendActionButton -> TODO()
         }
     }
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/setting/SettingViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/setting/SettingViewModel.kt
@@ -1,13 +1,19 @@
 package com.yapp.feature.home.setting
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.yapp.core.ui.mvi.MviIntentStore
 import com.yapp.core.ui.mvi.mviIntentStore
+import com.yapp.domain.LogoutUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SettingViewModel @Inject constructor() : ViewModel() {
+class SettingViewModel @Inject constructor(
+    private val logoutUseCase: LogoutUseCase,
+) : ViewModel() {
 
     val store: MviIntentStore<SettingState, SettingIntent, SettingSideEffect> =
         mviIntentStore(
@@ -23,6 +29,7 @@ class SettingViewModel @Inject constructor() : ViewModel() {
     ) {
         when (intent) {
             is SettingIntent.ClickNotificationSwitch -> {
+                // TODO 서버 API 호출
                 reduce { copy(isNotificationEnabled = intent.enabled) }
             }
             SettingIntent.ClickLogoutButton -> {
@@ -55,7 +62,13 @@ class SettingViewModel @Inject constructor() : ViewModel() {
             }
 
             SettingIntent.ClickDeleteAccountDialogRecommendActionButton -> TODO()
-            SettingIntent.ClickLogoutDialogRecommendActionButton -> TODO()
+
+            SettingIntent.ClickLogoutDialogRecommendActionButton -> {
+                viewModelScope.launch {
+                    logoutUseCase()
+                    postSideEffect(SettingSideEffect.NavigateToLogin)
+                }
+            }
         }
     }
 }

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -8,4 +8,11 @@
     <string name="setting_screen_item_inquiry">이용문의</string>
     <string name="setting_screen_item_delete_account">회원탈퇴</string>
     <string name="setting_screen_item_logout">로그아웃</string>
+    <string name="logout_dialog_title">로그아웃 할까요?</string>
+    <string name="logout_dialog_action_button">아니요!</string>
+    <string name="logout_dialog_recommend_action_button">로그아웃</string>
+    <string name="delete_account_dialog_title">정말 탈퇴하시겠어요?</string>
+    <string name="delete_account_dialog_body">탈퇴하시면 모든 정보가 삭제돼요.</string>
+    <string name="delete_account_dialog_action_button">아니요!</string>
+    <string name="delete_account_dialog_recommend_action_button">탈퇴하기</string>
 </resources>


### PR DESCRIPTION
## 💡 Issue
- Resolved: #66 

## 🌱 Key changes
<!--변경사항 적기-->
- 로그아웃, 이용약관 클릭 시 브라우저 이동, 다이얼로그 노출 로직 구현했습니다.
- 로그아웃의 경우 토큰 날리는 것까지 구현했어요

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
- Url Object에 각종 Url 넣어주시면 될 듯 합니다!

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- 설정 화면에서 로그아웃 및 계정 삭제 기능 추가
	- 개인정보 처리방침 및 이용약관 링크 제공

- **사용자 경험 개선**
	- 홈 라우트 초기 화면을 설정 화면으로 변경
	- 로그아웃 및 계정 삭제 시 확인 대화상자 추가

- **기타 변경사항**
	- 내부 코드 구조 및 패키지 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->