### PR TITLE
Qa/8 9 12 13 15 17

### DIFF
--- a/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
+++ b/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
@@ -10,7 +10,6 @@ import com.yapp.app.official.ui.clearBackStackNavOptions
 import com.yapp.feature.home.navigation.homeNavGraph
 import com.yapp.feature.home.navigation.settingNavGraph
 import com.yapp.feature.login.navigation.loginNavGraph
-import com.yapp.feature.notice.navigation.NoticeDetailRoute
 import com.yapp.feature.notice.navigation.noticeDetailNavGraph
 import com.yapp.feature.notice.navigation.noticeNavGraph
 import com.yapp.feature.signup.navigation.signupNavGraph
@@ -48,7 +47,10 @@ fun YappNavHost(
             navigateSetting = { navigator.navigateSettingScreen() },
             navigateLogin = {navigator.navigateLoginScreen(
                 navOptions = clearBackStackNavOptions
-            )}
+            )},
+            navigateToNoticeDetail = { noticeId ->
+                navigator.navigateToNoticeDetail(noticeId)
+            }
         )
         settingNavGraph(
             navigateLogin = {

--- a/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
+++ b/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
@@ -27,7 +27,7 @@ fun YappNavHost(
         exitTransition = { ExitTransition.None },
     ) {
         loginNavGraph(
-            navigateSignUp = { navigator.navigateSignUpScreen() },
+            navigateSignUp = { step -> navigator.navigateSignUpScreen(step) },
             navigateHome = {
                 navigator.navigateHomeScreen(
                     navOptions = clearBackStackNavOptions

--- a/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
+++ b/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
@@ -13,6 +13,7 @@ import com.yapp.feature.login.navigation.loginNavGraph
 import com.yapp.feature.notice.navigation.noticeDetailNavGraph
 import com.yapp.feature.notice.navigation.noticeNavGraph
 import com.yapp.feature.signup.navigation.signupNavGraph
+import com.yapp.feature.signup.signup.SignUpStep
 
 @Composable
 fun YappNavHost(
@@ -27,7 +28,9 @@ fun YappNavHost(
         exitTransition = { ExitTransition.None },
     ) {
         loginNavGraph(
-            navigateSignUp = { step -> navigator.navigateSignUpScreen(step) },
+            navigateSignUpName = { navigator.navigateSignUpScreen(SignUpStep.Name.name) },
+            navigateSignUpPending = {navigator.navigateSignUpScreen(SignUpStep.Pending.name)},
+            navigateSignUpReject = {navigator.navigateSignUpScreen(SignUpStep.Reject.name)},
             navigateHome = {
                 navigator.navigateHomeScreen(
                     navOptions = clearBackStackNavOptions

--- a/app/src/main/java/com/yapp/app/official/ui/Navigator.kt
+++ b/app/src/main/java/com/yapp/app/official/ui/Navigator.kt
@@ -42,8 +42,8 @@ class NavigatorState(
         navController.navigateToLogin(navOptions)
     }
 
-    fun navigateSignUpScreen() {
-        navController.navigateToSignUp()
+    fun navigateSignUpScreen(step : String) {
+        navController.navigateToSignUp(step)
     }
 
     fun navigateHomeScreen(navOptions: NavOptions? = null) {

--- a/core/data/src/main/java/com/yapp/core/data/remote/model/response/NoticeListResponse.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/model/response/NoticeListResponse.kt
@@ -8,13 +8,13 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class NoticeListResponse(
     val data: List<NoticeData>,
-    val lastCursor: String,
+    val lastCursor: String?,
     val limit: Int,
     val hasNext: Boolean
 ){
     fun toNoticeListModel() = NoticeList(
         notices = data.map { it.toNoticeModel() },
-        lastNoticeId = lastCursor,
+        lastNoticeId = lastCursor?: "",
         hasNext = hasNext
     )
 }

--- a/core/model/src/main/java/com/yapp/model/exceptions/YappExceptions.kt
+++ b/core/model/src/main/java/com/yapp/model/exceptions/YappExceptions.kt
@@ -10,6 +10,7 @@ enum class YappServerError(val exception: YappException) {
     USR_1003(UnprocessedSignUpException()),
 
     // 로그인
+    USR_0002(InternalServerException()),
     USR_1101(UserNotFoundForEmailException()),
     USR_1102(SignUpPendingException()),
     USR_1103(RecentSignUpRejectedException()),

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeContract.kt
@@ -18,10 +18,12 @@ sealed interface HomeIntent {
     data object ClickMoreButton : HomeIntent
     data object ClickSettingButton : HomeIntent
     data object EnterHomeScreen : HomeIntent
+    data class ClickNoticeItem(val noticeId: String) : HomeIntent
 }
 
 sealed interface HomeSideEffect {
     data object NavigateToNotice : HomeSideEffect
+    data class NavigateToNoticeDetail(val noticeId: String) : HomeSideEffect
     data object NavigateToSetting : HomeSideEffect
     data object NavigateToLogin : HomeSideEffect
     data class ShowToast(val message: String) : HomeSideEffect

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeScreen.kt
@@ -94,7 +94,7 @@ fun HomeScreen(
                     )
                     Spacer(Modifier.height(8.dp))
                     NoticeSection(
-                        noticeInfo = hmeState.noticeInfo,
+                        noticeInfo = homeState.noticeInfo,
                         onMoreButtonClick = { onIntent(HomeIntent.ClickMoreButton) },
                         onNoticeDetailClick = { onIntent(HomeIntent.ClickNoticeItem(it)) }
                     )

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeScreen.kt
@@ -30,6 +30,7 @@ internal fun HomeRoute(
     navigateToNotice: () -> Unit,
     navigateToSetting: () -> Unit,
     navigateToLogin: () -> Unit,
+    navigateToNoticeDetail: (String) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(Unit) {
@@ -45,7 +46,9 @@ internal fun HomeRoute(
             is HomeSideEffect.ShowToast -> {
                 Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
             }
+
             HomeSideEffect.NavigateToLogin -> navigateToLogin()
+            is HomeSideEffect.NavigateToNoticeDetail -> navigateToNoticeDetail(effect.noticeId)
         }
     }
 
@@ -77,7 +80,11 @@ fun HomeScreen(
                 if (homeState.isLoading) {
                     ProfileLoadingSection(homeState.name)
                     Spacer(Modifier.height(8.dp))
-                    NoticeSection(null, onMoreButtonClick = { onIntent(HomeIntent.ClickMoreButton)})
+                    NoticeSection(
+                        null,
+                        onMoreButtonClick = { onIntent(HomeIntent.ClickMoreButton) },
+                        onNoticeDetailClick = { onIntent(HomeIntent.ClickNoticeItem(it)) }
+                    )
                 } else {
                     ProfileSection(
                         name = homeState.name,
@@ -87,8 +94,9 @@ fun HomeScreen(
                     )
                     Spacer(Modifier.height(8.dp))
                     NoticeSection(
-                        noticeInfo = homeState.noticeInfo,
-                        onMoreButtonClick = { onIntent(HomeIntent.ClickMoreButton) }
+                        noticeInfo = hmeState.noticeInfo,
+                        onMoreButtonClick = { onIntent(HomeIntent.ClickMoreButton) },
+                        onNoticeDetailClick = { onIntent(HomeIntent.ClickNoticeItem(it)) }
                     )
                 }
             }
@@ -103,7 +111,8 @@ private fun HomeScreenPreview() {
         HomeRoute(
             navigateToLogin = {},
             navigateToNotice = {},
-            navigateToSetting = {}
+            navigateToSetting = {},
+            navigateToNoticeDetail = {}
         )
     }
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package com.yapp.feature.home
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yapp.core.common.android.record
@@ -42,6 +41,7 @@ class HomeViewModel @Inject constructor(
             HomeIntent.ClickMoreButton -> postSideEffect(HomeSideEffect.NavigateToNotice)
             HomeIntent.ClickSettingButton -> postSideEffect(HomeSideEffect.NavigateToSetting)
             HomeIntent.EnterHomeScreen -> { loadHomeInfo( reduce,postSideEffect)  }
+            is HomeIntent.ClickNoticeItem -> postSideEffect(HomeSideEffect.NavigateToNoticeDetail(intent.noticeId))
         }
     }
 

--- a/feature/home/src/main/java/com/yapp/feature/home/component/NoticeSection.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/component/NoticeSection.kt
@@ -20,6 +20,7 @@ import com.yapp.model.NoticeList
 @Composable
 fun NoticeSection(
     noticeInfo: NoticeList?,
+    onNoticeDetailClick: (String) -> Unit,
     onMoreButtonClick: () -> Unit,
 ) {
     HomeSectionBackground {
@@ -52,7 +53,8 @@ fun NoticeSection(
                             color = YappTheme.colorScheme.lineNormalAlternative
                         )
                     },
-                    noticeInfo = noticeInfo.notices[it]
+                    noticeInfo = noticeInfo.notices[it],
+                    onClick = { onNoticeDetailClick(noticeInfo.notices[it].id)}
                 )
             }
         }

--- a/feature/home/src/main/java/com/yapp/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/navigation/HomeNavigation.kt
@@ -25,13 +25,17 @@ fun NavController.navigateToSetting(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.homeNavGraph(
     navigateNotice: () -> Unit,
     navigateSetting: () -> Unit,
-    navigateLogin : () -> Unit
+    navigateLogin : () -> Unit,
+    navigateToNoticeDetail: (String) -> Unit
 ) {
     composable<HomeRoute> {
         HomeRoute(
             navigateToNotice = navigateNotice,
             navigateToSetting = navigateSetting,
-            navigateToLogin = navigateLogin
+            navigateToLogin = navigateLogin,
+            navigateToNoticeDetail = { noticeId ->
+                navigateToNoticeDetail(noticeId)
+            }
         )
     }
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginContract.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginContract.kt
@@ -33,6 +33,7 @@ sealed interface LoginSideEffect {
     data object NavigateToSignUp : LoginSideEffect
     data object NavigateToHome : LoginSideEffect
     data object NavigateToSignUpPending : LoginSideEffect
+    data object NavigateToSignUpReject : LoginSideEffect
     data class OpenWebBrowser(val link: String) : LoginSideEffect
     data class ShowToast(val message: String) : LoginSideEffect
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginContract.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginContract.kt
@@ -32,6 +32,7 @@ sealed interface LoginIntent {
 sealed interface LoginSideEffect {
     data object NavigateToSignUp : LoginSideEffect
     data object NavigateToHome : LoginSideEffect
+    data object NavigateToSignUpPending : LoginSideEffect
     data class OpenWebBrowser(val link: String) : LoginSideEffect
     data class ShowToast(val message: String) : LoginSideEffect
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
@@ -29,7 +29,9 @@ import com.yapp.feature.login.component.TopTitle
 
 @Composable
 internal fun LoginRoute(
-    navigateToSignup: (String) -> Unit,
+    navigateToSignupName: () -> Unit,
+    navigateToSignupPending: () -> Unit,
+    navigateToSignupReject: () -> Unit,
     navigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = hiltViewModel(),
@@ -43,7 +45,7 @@ internal fun LoginRoute(
 
     viewModel.store.sideEffects.collectWithLifecycle { effect ->
         when (effect) {
-            LoginSideEffect.NavigateToSignUp -> navigateToSignup("Name")
+            LoginSideEffect.NavigateToSignUp -> navigateToSignupName()
             is LoginSideEffect.OpenWebBrowser -> {
                 context.openUrl(effect.link)
             }
@@ -52,8 +54,8 @@ internal fun LoginRoute(
             is LoginSideEffect.ShowToast -> {
                 Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
             }
-            LoginSideEffect.NavigateToSignUpPending -> navigateToSignup("Pending")
-            LoginSideEffect.NavigateToSignUpReject -> navigateToSignup("Reject")
+            LoginSideEffect.NavigateToSignUpPending -> navigateToSignupPending()
+            LoginSideEffect.NavigateToSignUpReject -> navigateToSignupReject()
         }
     }
     LoginScreen(
@@ -116,6 +118,11 @@ fun LoginScreen(
 @Composable
 private fun LoginScreenPreview() {
     YappTheme {
-        LoginRoute({}, {})
+        LoginRoute(
+            navigateToSignupName = {},
+            navigateToSignupPending = {},
+            navigateToSignupReject = {},
+            navigateToHome = {}
+        )
     }
 }

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
@@ -53,6 +53,7 @@ internal fun LoginRoute(
                 Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
             }
             LoginSideEffect.NavigateToSignUpPending -> navigateToSignup("Pending")
+            LoginSideEffect.NavigateToSignUpReject -> navigateToSignup("Reject")
         }
     }
     LoginScreen(

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginScreen.kt
@@ -29,7 +29,7 @@ import com.yapp.feature.login.component.TopTitle
 
 @Composable
 internal fun LoginRoute(
-    navigateToSignup: () -> Unit,
+    navigateToSignup: (String) -> Unit,
     navigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = hiltViewModel(),
@@ -43,8 +43,7 @@ internal fun LoginRoute(
 
     viewModel.store.sideEffects.collectWithLifecycle { effect ->
         when (effect) {
-            LoginSideEffect.NavigateToSignUp -> navigateToSignup()
-
+            LoginSideEffect.NavigateToSignUp -> navigateToSignup("Name")
             is LoginSideEffect.OpenWebBrowser -> {
                 context.openUrl(effect.link)
             }
@@ -53,6 +52,7 @@ internal fun LoginRoute(
             is LoginSideEffect.ShowToast -> {
                 Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
             }
+            LoginSideEffect.NavigateToSignUpPending -> navigateToSignup("Pending")
         }
     }
     LoginScreen(

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
@@ -9,6 +9,7 @@ import com.yapp.dataapi.OperationsRepository
 import com.yapp.domain.LoginUseCase
 import com.yapp.model.Regex
 import com.yapp.model.exceptions.InvalidRequestArgument
+import com.yapp.model.exceptions.SignUpPendingException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -128,6 +129,10 @@ class LoginViewModel @Inject constructor(
                                     passwordErrorDescription = "비밀번호가 달라요. 입력하신 비밀번호를 확인해주세요."
                                 )
                             }
+                        }
+                        is SignUpPendingException -> {
+                            // 회원가입 대기 화면으로 이동
+                            postSideEffect(LoginSideEffect.NavigateToSignUpPending)
                         }
 
                         else -> {

--- a/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/LoginViewModel.kt
@@ -9,6 +9,7 @@ import com.yapp.dataapi.OperationsRepository
 import com.yapp.domain.LoginUseCase
 import com.yapp.model.Regex
 import com.yapp.model.exceptions.InvalidRequestArgument
+import com.yapp.model.exceptions.RecentSignUpRejectedException
 import com.yapp.model.exceptions.SignUpPendingException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.catch
@@ -134,7 +135,9 @@ class LoginViewModel @Inject constructor(
                             // 회원가입 대기 화면으로 이동
                             postSideEffect(LoginSideEffect.NavigateToSignUpPending)
                         }
-
+                        is RecentSignUpRejectedException -> {
+                            postSideEffect(LoginSideEffect.NavigateToSignUpReject)
+                        }
                         else -> {
                             postSideEffect(LoginSideEffect.ShowToast(errorMessage))
                         }

--- a/feature/login/src/main/java/com/yapp/feature/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/navigation/LoginNavigation.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.Serializable
 fun NavController.navigateToLogin(navOptions: NavOptions? = null) { navigate(LoginRoute, navOptions) }
 
 fun NavGraphBuilder.loginNavGraph(
-    navigateSignUp: () -> Unit,
+    navigateSignUp: (String) -> Unit,
     navigateHome: () -> Unit,
     ){
     composable<LoginRoute> {

--- a/feature/login/src/main/java/com/yapp/feature/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/yapp/feature/login/navigation/LoginNavigation.kt
@@ -12,10 +12,17 @@ import kotlinx.serialization.Serializable
 fun NavController.navigateToLogin(navOptions: NavOptions? = null) { navigate(LoginRoute, navOptions) }
 
 fun NavGraphBuilder.loginNavGraph(
-    navigateSignUp: (String) -> Unit,
+    navigateSignUpName: () -> Unit,
+    navigateSignUpPending : () -> Unit,
+    navigateSignUpReject : () -> Unit,
     navigateHome: () -> Unit,
     ){
     composable<LoginRoute> {
-        LoginRoute(navigateSignUp,navigateHome)
+        LoginRoute(
+            navigateToSignupName = navigateSignUpName,
+            navigateToSignupPending = navigateSignUpPending,
+            navigateToSignupReject =navigateSignUpReject ,
+            navigateToHome = navigateHome
+        )
     }
 }

--- a/feature/signup/src/main/java/com/yapp/feature/signup/navigation/SignUpNavigation.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/navigation/SignUpNavigation.kt
@@ -8,10 +8,10 @@ import com.yapp.feature.signup.signup.SignUpRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object SignUpRoute
+data class SignUpRoute(val currentStep : String)
 
-fun NavController.navigateToSignUp(navOptions: NavOptions? = null) {
-    navigate(SignUpRoute, navOptions)
+fun NavController.navigateToSignUp(step : String, navOptions: NavOptions? = null) {
+    navigate(SignUpRoute(step), navOptions)
 }
 
 fun NavGraphBuilder.signupNavGraph(

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpContract.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpContract.kt
@@ -55,5 +55,15 @@ sealed interface SignUpSideEffect {
 }
 
 enum class SignUpStep {
-    Name, Email, Password, Position, Complete, Pending
+    Name, Email, Password, Position, Complete, NamePending;
+
+    companion object {
+        fun from(value: String?): SignUpStep {
+            return try {
+                value?.let { valueOf(it) } ?: Name
+            } catch (e: Exception) {
+                Name
+            }
+        }
+    }
 }

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpContract.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpContract.kt
@@ -55,7 +55,7 @@ sealed interface SignUpSideEffect {
 }
 
 enum class SignUpStep {
-    Name, Email, Password, Position, Complete, NamePending;
+    Name, Email, Password, Position, Complete, Pending;
 
     companion object {
         fun from(value: String?): SignUpStep {

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpContract.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpContract.kt
@@ -27,6 +27,7 @@ data class SignUpState(
     }
 
     val showPendingButton = currentStep == SignUpStep.Pending
+    val showRejectButton = currentStep == SignUpStep.Reject
 }
 
 sealed interface SignUpIntent {
@@ -43,7 +44,6 @@ sealed interface SignUpIntent {
     data object ClickNoSignUpCodeButton : SignUpIntent
     data object ClickInputCompleteButton : SignUpIntent
     data object ClickPendingButton : SignUpIntent
-
     data class ChangeSignUpCode(val signUpCode: String) : SignUpIntent
 }
 
@@ -55,7 +55,7 @@ sealed interface SignUpSideEffect {
 }
 
 enum class SignUpStep {
-    Name, Email, Password, Position, Complete, Pending;
+    Name, Email, Password, Position, Complete, Pending, Reject;
 
     companion object {
         fun from(value: String?): SignUpStep {

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.yapp.core.designsystem.component.button.outlined.YappOutlinedPrimaryButtonXLarge
 import com.yapp.core.designsystem.component.button.solid.YappSolidPrimaryButtonLarge
 import com.yapp.core.designsystem.component.button.solid.YappSolidPrimaryButtonXLarge
 import com.yapp.core.designsystem.component.button.text.YappTextAssistiveButtonMedium

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpScreen.kt
@@ -39,6 +39,7 @@ import com.yapp.feature.signup.signup.component.SignUpCodeBottomDialog
 import com.yapp.feature.signup.signup.extension.signUpAnimatedContentTransitionSpec
 import com.yapp.feature.signup.signup.page.CompletePage
 import com.yapp.feature.signup.signup.page.PendingPage
+import com.yapp.feature.signup.signup.page.RejectPage
 import com.yapp.feature.signup.signup.page.email.EmailPage
 import com.yapp.feature.signup.signup.page.name.NamePage
 import com.yapp.feature.signup.signup.page.password.PasswordPage
@@ -140,6 +141,7 @@ fun SignUpScreen(
 
                     SignUpStep.Complete -> CompletePage()
                     SignUpStep.Pending -> PendingPage()
+                    SignUpStep.Reject -> RejectPage()
                 }
             }
 
@@ -181,7 +183,18 @@ private fun SignUpScreenButton(
             text = stringResource(R.string.signup_screen_pending_assistive_button),
             onClick = { onIntent(SignUpIntent.ClickPendingButton) }
         )
+        Spacer(Modifier.height(20.dp))
+        return
+    }
 
+    if (uiState.showRejectButton){
+        YappTextAssistiveButtonMedium(
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .fillMaxWidth(),
+            text = stringResource(R.string.signup_screen_reject_assistive_button),
+            onClick = { onIntent(SignUpIntent.ClickPendingButton) }
+        )
         Spacer(Modifier.height(20.dp))
         return
     }

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpViewModel.kt
@@ -1,5 +1,6 @@
 package com.yapp.feature.signup.signup
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yapp.core.common.android.record
@@ -25,15 +26,25 @@ class SignUpViewModel @Inject constructor(
     private val signUpUseCase: SignUpUseCase,
     private val getPositionConfigsUseCase: GetPositionConfigsUseCase,
     private val operationsRepository: OperationsRepository,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     private var signUpInfo = SignUpInfo()
     private var inquiryLink = ""
+
+    companion object {
+        private const val STEP_ID_KEY = "currentStep"
+    }
+
+    private val step: String =
+        requireNotNull(savedStateHandle.get<String>(STEP_ID_KEY)) { "Name" }
+
 
     val store: MviIntentStore<SignUpState, SignUpIntent, SignUpSideEffect> =
         mviIntentStore(
             initialState = SignUpState(),
             onIntent = ::onIntent
         )
+
 
     private fun onIntent(
         intent: SignUpIntent,
@@ -42,7 +53,8 @@ class SignUpViewModel @Inject constructor(
         postSideEffect: (SignUpSideEffect) -> Unit,
     ) {
         when (intent) {
-            SignUpIntent.EnterScreen -> {
+            is SignUpIntent.EnterScreen -> {
+                reduce{copy(currentStep= SignUpStep.from(step))}
                 getPositionConfigsUseCase()
                     .onEach {
                         reduce { copy(positions = it) }

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpViewModel.kt
@@ -80,6 +80,7 @@ class SignUpViewModel @Inject constructor(
                     SignUpStep.Password -> SignUpStep.Email
                     SignUpStep.Email -> SignUpStep.Name
                     SignUpStep.Pending,
+                    SignUpStep.Reject,
                     SignUpStep.Name -> {
                         postSideEffect(SignUpSideEffect.NavigateBack)
                         return
@@ -115,6 +116,7 @@ class SignUpViewModel @Inject constructor(
                     SignUpStep.Password -> SignUpStep.Position
                     SignUpStep.Position,
                     SignUpStep.Complete,
+                    SignUpStep.Reject,
                     SignUpStep.Pending -> return
                 }
 
@@ -225,6 +227,7 @@ class SignUpViewModel @Inject constructor(
             SignUpStep.Password -> signUpInfo.isAllPasswordConditionValid
             SignUpStep.Position -> signUpInfo.isActivityUnitsValid
             SignUpStep.Complete,
+            SignUpStep.Reject,
             SignUpStep.Pending -> true
         }
     }

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpViewModel.kt
@@ -12,6 +12,7 @@ import com.yapp.domain.SignUpUseCase
 import com.yapp.model.SignUpInfo
 import com.yapp.model.SignUpResult
 import com.yapp.model.exceptions.SignUpCodeException
+import com.yapp.model.exceptions.UnprocessedSignUpException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
@@ -211,6 +212,7 @@ class SignUpViewModel @Inject constructor(
             .onFailure {
                 when (it) {
                     is SignUpCodeException -> reduce { copy(signUpErrorInputTextDescription = it.message) }
+                    is UnprocessedSignUpException -> reduce { copy(currentStep = SignUpStep.Pending, showSignUpCodeBottomDialog = false)}
                     else -> it.record()
                 }
             }

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/page/RejectPage.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/page/RejectPage.kt
@@ -1,0 +1,39 @@
+package com.yapp.feature.signup.signup.page
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.yapp.core.designsystem.theme.YappTheme
+import com.yapp.core.ui.component.YappBackground
+import com.yapp.feature.signup.R
+
+
+@Composable
+fun RejectPage() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.signup_screen_reject_title),
+            style = YappTheme.typography.title3Bold,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun RejectContentPreview() {
+    YappTheme {
+        YappBackground {
+            RejectPage()
+        }
+    }
+}

--- a/feature/signup/src/main/res/values/strings.xml
+++ b/feature/signup/src/main/res/values/strings.xml
@@ -46,6 +46,8 @@
     <string name="signup_screen_complete_description">정상적으로 회원가입이 완료되었습니다.\n이제 즐거운 YAPP 즐길 준비 완료!!</string>
     <string name="signup_screen_pending_title">아직 가입 대기중이에요...</string>
     <string name="signup_screen_pending_description">회원가입을 완료하려면 승인이 필요해요.\n운영진에게 승인을 요청해보세요.</string>
+    <string name="signup_screen_reject_title">회원가입이 거절되었어요.</string>
+    <string name="signup_screen_reject_assistive_button">운영진에게 문의하기</string>
     <string name="signup_screen_position_previous_generation">이전 기수 %d</string>
     <string name="signup_screen_position_previous_delete_content_description">이전 활동 기수 %d 삭제</string>
     <string name="signup_screen_pending_assistive_button">대기상태가 계속되고 있나요?</string>


### PR DESCRIPTION
## 🌱 Key changes
노션 QA 시트에 있는 번호 기준입니다~

- No.8 :  공지사항 클릭 시 공지사항 디테일로 이동되지 않은 건 -> 이동하도록 수정
- No.9 : 회원가입 대기중인 계정 로그인 시도시 화면 이동 안됨 -> 대기중 화면으로 이동
- No.12 : 회원가입 대기중인 계정 회원가입 시도시 크래시 -> 대기중 화면으로 이동
- No.13 : 탈퇴한 계정 로그인시 무반응 -> 토스트 노출 ( 기획 협의 )
- No.15 : 회원가입 거절된 계정으로 로그인 시도시 화면 이동 안됨 -> 거절 화면으로 이동 ( 거절 사유 미제공 / 기획 협의 )
- No.17 : 공지사항 운영탭 클릭 크래시 -> 서버 수정 요청 & null 처리 추가


## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

가입 거절된 계정 공유 
id : jjaewon@admin.com
pw : wodnjs0813!

대기중인 계정 -> 회원가입 시도하면 생성 가능합니다!

