### PR TITLE
Feature/#123 notice infinite scroll

### DIFF
--- a/feature/home/src/main/java/com/yapp/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeContract.kt
@@ -8,7 +8,7 @@ data class HomeState(
     val name : String = "",
     val role : UserRole = UserRole.ACTIVE,
     val activityUnits : List<ActivityUnit> = listOf(ActivityUnit(position = "", generation = 0)),
-    var noticeInfo: NoticeList = NoticeList(notices = listOf(), lastNoticeId = "", hasNext = false),
+    val noticeInfo: NoticeList = NoticeList(notices = listOf(), lastNoticeId = "", hasNext = false),
     val isLoading: Boolean = true,  // 전체 스켈레톤 여부
     val isUserInfoLoading: Boolean = true, // 사용자 정보 로딩 여부
     val isNoticesLoading: Boolean = true,  // 공지사항 로딩 여부

--- a/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeContract.kt
+++ b/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeContract.kt
@@ -20,6 +20,7 @@ sealed interface NoticeIntent {
     data object ClickBackButton : NoticeIntent
     data class ClickNoticeType(val noticeType: NoticeType) : NoticeIntent
     data class ClickNoticeItem(val noticeId: String) : NoticeIntent
+    data object LoadMoreNoticeItem : NoticeIntent
 }
 
 sealed interface NoticeSideEffect {

--- a/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeRoute.kt
+++ b/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeRoute.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -28,6 +30,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yapp.core.designsystem.component.gradient.GradientBottom
 import com.yapp.core.designsystem.component.header.YappHeaderActionbarExpanded
+import com.yapp.core.designsystem.extension.OnBottomReached
 import com.yapp.core.designsystem.theme.YappTheme
 import com.yapp.core.ui.component.NoticeItem
 import com.yapp.core.ui.component.NoticeLoadingItem
@@ -67,6 +70,8 @@ fun NoticeScreen(
     uiState: NoticeState = NoticeState(),
     onIntent: (NoticeIntent) -> Unit = {},
 ) {
+    val lazyScrollState = rememberLazyListState()
+
     YappBackground {
         Column {
             YappHeaderActionbarExpanded(
@@ -131,6 +136,7 @@ fun NoticeScreen(
                     LazyColumn(
                         modifier = Modifier.padding(horizontal = 20.dp),
                         contentPadding = PaddingValues(vertical = 16.dp),
+                        state = lazyScrollState
                     ) {
                         if (uiState.isNoticesLoading) {
                             items(count = 7) {
@@ -162,6 +168,10 @@ fun NoticeScreen(
             }
         }
 
+    }
+
+    lazyScrollState.OnBottomReached {
+        onIntent.invoke(NoticeIntent.LoadMoreNoticeItem)
     }
 }
 

--- a/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeRoute.kt
+++ b/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeRoute.kt
@@ -171,7 +171,7 @@ fun NoticeScreen(
     }
 
     lazyScrollState.OnBottomReached {
-        onIntent.invoke(NoticeIntent.LoadMoreNoticeItem)
+        onIntent(NoticeIntent.LoadMoreNoticeItem)
     }
 }
 

--- a/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeRoute.kt
+++ b/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeRoute.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect


### PR DESCRIPTION
## 💡 Issue
- Resolved: #123 

## 🌱 Key changes
<!--변경사항 적기-->

- 공지사항 리스트 값이 화면 진입시 초기 상태와 로드모어 시 구분을 지으려고 하셨던거 같은데 동일한 함수로 사용했습니다.
- 초기 진입 시 데이터가 가변으로 되어있어서 val 로 변경하였습니다.
- 로드모어 이벤트 인텐트 값을 추가하였고 그에 따른 컴포저블 로직 구현을 추가했습니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
공지사항 limit 값이 30 으로 고정되어있어서 영상에는 무한 스크롤이 없는것으로 보여집니다.
limit 값을 조절하면서 스크롤 기능이 되는걸 확인하였습니다.
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->


https://github.com/user-attachments/assets/43a97ec6-09d3-4b4a-bcaf-ecf0c5128b58




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 스크롤 시 공지사항 목록 하단에 도달하면 추가 공지가 자동으로 로드되어 사용자 경험이 향상되었습니다.
  - 페이지네이션 기능이 도입되어 공지사항 불러오기가 개선되었습니다.

- **리팩토링**
  - 내부 상태 관리가 개선되어 공지사항 데이터 처리의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->