### PR TITLE
Chore/#127 QA build variant 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,12 @@ android {
         getByName("release") {
             signingConfig = signingConfigs.getByName("release")
         }
+
+        create("qa") {
+            initWith(getByName("release"))
+            signingConfig = signingConfigs.getByName("release")
+            matchingFallbacks += listOf("release")
+        }
     }
 }
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.yapp.app.setNamespace
 import org.gradle.internal.extensions.stdlib.capitalized
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.util.Properties
 
 plugins {
     id("yapp.android.library")
@@ -13,6 +14,25 @@ android {
 
     buildFeatures {
         buildConfig = true
+    }
+
+    buildTypes {
+        val localProperties = Properties()
+        localProperties.load(
+            project.rootProject.file("local.properties").bufferedReader()
+        )
+
+        getByName("debug") {
+            buildConfigField("String", "BASE_URL", "\"${localProperties["base.url.debug"]}\"")
+        }
+        getByName("release") {
+            buildConfigField("String", "BASE_URL", "\"${localProperties["base.url.release"]}\"")
+        }
+        create("qa") {
+            initWith(getByName("release"))
+            matchingFallbacks += listOf("release")
+            buildConfigField("String", "BASE_URL", "\"${localProperties["base.url.qa"]}\"")
+        }
     }
 }
 

--- a/core/data/src/main/java/com/yapp/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/di/NetworkModule.kt
@@ -26,12 +26,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 internal object NetworkModule {
 
-    private val BASE_URL: String
-        get() = if (BuildConfig.DEBUG) {
-            "https://dev-yappuworld.yapp.co.kr/"
-        } else {
-            "https://api-yappuworld.yapp.co.kr/"
-        }
+    private const val BASE_URL: String = BuildConfig.BASE_URL
 
     @Singleton
     @Provides


### PR DESCRIPTION
## 💡 Issue
- Resolved: #127 

## 🌱 Key changes
<!--변경사항 적기-->
<img width="565" alt="image" src="https://github.com/user-attachments/assets/65edaa71-dace-46df-84e2-14c3e10572a7" />

- release로 빌드하되 서버의 BASE URL은 개발 서버를 바라보도록 QA build variant를 추가했습니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
실기기로 테스트를 거치긴 했는데 그래도 여유되시면 테스트 한번 해주시고 Approve 해주시면 감사하겠습니다.

```kotlin
base.url.debug=https://dev-yappuworld.yapp.co.kr/
base.url.release=https://api-yappuworld.yapp.co.kr/
base.url.qa=https://dev-yappuworld.yapp.co.kr/
```
baseUrl 정보는 local.properties에 추가하시면 됩니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 품질 보증을 위한 새로운 QA 빌드 환경이 추가되었습니다.
  - 디버그, QA, 릴리즈 각 환경에 맞춰 기본 URL 설정이 가능해졌습니다.

- **리팩토링**
  - 네트워크 기본 URL 할당 방식을 단순화하여, 외부 설정 값을 기반으로 구성하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->