### PR TITLE
Chore/#147 :  빌드 환경에 따라 applicationId를 분기

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,14 +29,21 @@ android {
         targetSdk = 35
     }
     buildTypes {
-        getByName("release") {
-            signingConfig = signingConfigs.getByName("release")
+        getByName("debug") {
+            applicationIdSuffix = ".dev"
+            isDebuggable = true
         }
 
         create("qa") {
             initWith(getByName("release"))
+            applicationIdSuffix = ".qa"
             signingConfig = signingConfigs.getByName("release")
             matchingFallbacks += listOf("release")
+            isDebuggable = true
+        }
+
+        getByName("release") {
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Yapp Official DEV</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">YappOfficial</string>
+    <string name="app_name">Yapp Official</string>
     <string name="main_activity_force_update_dialog_title">업데이트가 필요해요!</string>
     <string name="main_activity_force_update_dialog_body">더 안전하고 원활한 사용을 위해 최신 버전이 필요합니다. 업데이트 후 계속 이용해 주세요!</string>
     <string name="main_activity_force_update_dialog_button_text">업데이트 하러가기</string>

--- a/app/src/qa/res/values/strings.xml
+++ b/app/src/qa/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Yapp Official QA</string>
+</resources>


### PR DESCRIPTION
## 💡 Issue
- Resolved: #147 

## 🌱 Key changes
<!--변경사항 적기-->
- build.gradle에서 debug, qa 빌드 타입에 대해 applicationIdSuffix = ".dev", ".qa" 설정을 추가했습니다.
- 빌드 타입에 따라 앱 이름(app_name)을 Yapp Official DEV, Yapp Official QA, Yapp Official로 분기되도록 처리했습니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

<img width="424" alt="image" src="https://github.com/user-attachments/assets/2aa51958-7f31-4e0c-b41c-e7606eb723e8" />

![image](https://github.com/user-attachments/assets/f85f481d-e89d-4e39-90d5-b49ac51d09d3)


google-services.json 업데이트 필요합니다.
release 빌드는 `/app` 폴더에 dev 빌드는 `/app/src/debug`에 qa 빌드는 `/app/src/qa` 폴더에 넣으시면 됩니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|![image](https://github.com/user-attachments/assets/a5625dc9-ef1d-4f7b-94a5-bd3fec95aaa4)|

YAPP이 3개


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - QA 및 Debug 빌드 타입이 추가되어 각 환경별로 앱 이름과 식별자가 구분됩니다.

- **버그 수정**
  - 앱 이름이 "YappOfficial"에서 "Yapp Official"로 수정되었습니다.

- **기타**
  - QA 및 Debug 빌드 환경에서 앱 이름이 각각 "Yapp Official QA", "Yapp Official DEV"로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->