### PR TITLE
Feature/#156 홈 UI 수정

### DIFF
--- a/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
+++ b/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
@@ -50,16 +50,14 @@ fun YappNavHost(
             }
         )
         homeNavGraph(
-            navigateNotice = { navigator.navigateNoticeScreen() },
-            navigateSetting = { navigator.navigateSettingScreen() },
             navigateLogin = {
                 navigator.navigateLoginScreen(
                     navOptions = clearBackStackNavOptions
                 )
             },
-            navigateToNoticeDetail = { noticeId ->
-                navigator.navigateToNoticeDetail(noticeId)
-            }
+            navigateSchedule = {
+                navigator.navigateToTopLevelDestination(TopLevelDestination.SCHEDULE)
+            },
         )
         settingNavGraph(
             navigateLogin = {

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeContract.kt
@@ -99,19 +99,15 @@ data class HomeState(
 }
 
 sealed interface HomeIntent {
-    data object ClickMoreButton : HomeIntent
-    data object ClickSettingButton : HomeIntent
     data object ClickRequestAttendCode : HomeIntent
     data object ClickDismissDialog : HomeIntent
     data class ClickRequestAttendance(val code: String, val sessionId: String) : HomeIntent
     data object EnterHomeScreen : HomeIntent
-    data class ClickNoticeItem(val noticeId: String) : HomeIntent
+    data object ClickShowAllSession : HomeIntent
 }
 
 sealed interface HomeSideEffect {
-    data object NavigateToNotice : HomeSideEffect
-    data class NavigateToNoticeDetail(val noticeId: String) : HomeSideEffect
-    data object NavigateToSetting : HomeSideEffect
+    data object NavigateToSchedule : HomeSideEffect
     data object NavigateToLogin : HomeSideEffect
     data class ShowToast(val message: String) : HomeSideEffect
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeScreen.kt
@@ -1,13 +1,8 @@
 package com.yapp.feature.home
 
 import android.widget.Toast
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -22,7 +17,7 @@ import com.yapp.core.ui.component.YappBackground
 import com.yapp.core.ui.extension.collectWithLifecycle
 import com.yapp.feature.home.component.HomeAttendanceContents
 import com.yapp.feature.home.component.HomeAttendanceNotice
-import com.yapp.feature.home.component.HomeStickHeader
+import com.yapp.feature.home.component.HomeHeader
 import com.yapp.feature.home.dialog.AttendanceDialog
 
 @Composable
@@ -58,13 +53,12 @@ internal fun HomeRoute(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomeScreen(
     homeState: HomeState,
     onIntent: (HomeIntent) -> Unit = {},
 ) {
-    val colorStops = arrayOf(
+    val colorSteps = arrayOf(
         0.2f to YappTheme.colorScheme.primaryNormal,
         1f to YappTheme.colorScheme.secondaryNormal
     )
@@ -72,42 +66,40 @@ fun HomeScreen(
     YappBackground(
         color = YappTheme.colorScheme.staticWhite
     ) {
-        LazyColumn(userScrollEnabled = false) {
-            stickyHeader {
-                HomeStickHeader(
-                    modifier = Modifier
-                        .background(brush = Brush.horizontalGradient(colorStops = colorStops))
-                        .padding(top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()),
-                    sessions = homeState.sessions,
-                    upcomingSessionId = homeState.upcomingSessionId,
-                    onClickSessionItem = { noticeId ->
-                        onIntent(HomeIntent.ClickNoticeItem(noticeId))
-                    }
-                )
-            }
+        Column {
+            HomeHeader(
+                modifier = Modifier
+                    .background(brush = Brush.horizontalGradient(colorStops = colorSteps)),
+                sessions = homeState.sessions,
+                upcomingSessionId = homeState.upcomingSessionId,
+                onClickSessionItem = { }
+            )
 
-            item { HomeAttendanceNotice(title = homeState.attendanceTitle) }
+            HomeAttendanceNotice(title = homeState.attendanceTitle)
 
-            item {
-                HomeAttendanceContents(
-                    todayOrUpcomingSession = homeState.todayOrUpcomingSession,
-                    attendState = homeState.attendState,
-                    buttonTitle = homeState.buttonTitle,
-                    onClickAttend = { onIntent(HomeIntent.ClickRequestAttendCode) }
-                )
-            }
-        }
-
-        if (homeState.showAttendCodeBottomSheet) {
-            AttendanceDialog(
-                onDismissRequest = {
-                    onIntent(HomeIntent.ClickDismissDialog)
-                },
-                clickAttendanceButton = { code ->
-                    onIntent(HomeIntent.ClickRequestAttendance(sessionId = homeState.todayOrUpcomingSession?.id.orEmpty(), code = code))
-                },
+            HomeAttendanceContents(
+                todayOrUpcomingSession = homeState.todayOrUpcomingSession,
+                attendState = homeState.attendState,
+                buttonTitle = homeState.buttonTitle,
+                onClickAttend = { onIntent(HomeIntent.ClickRequestAttendCode) }
             )
         }
+    }
+
+    if (homeState.showAttendCodeBottomSheet) {
+        AttendanceDialog(
+            onDismissRequest = {
+                onIntent(HomeIntent.ClickDismissDialog)
+            },
+            clickAttendanceButton = { code ->
+                onIntent(
+                    HomeIntent.ClickRequestAttendance(
+                        sessionId = homeState.todayOrUpcomingSession?.id.orEmpty(),
+                        code = code
+                    )
+                )
+            },
+        )
     }
 }
 

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeScreen.kt
@@ -22,10 +22,8 @@ import com.yapp.feature.home.dialog.AttendanceDialog
 
 @Composable
 internal fun HomeRoute(
-    navigateToNotice: () -> Unit,
-    navigateToSetting: () -> Unit,
     navigateToLogin: () -> Unit,
-    navigateToNoticeDetail: (String) -> Unit,
+    navigateToSchedule: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(Unit) {
@@ -36,14 +34,9 @@ internal fun HomeRoute(
     val context = LocalContext.current
     viewModel.store.sideEffects.collectWithLifecycle { effect ->
         when (effect) {
-            HomeSideEffect.NavigateToNotice -> navigateToNotice()
-            HomeSideEffect.NavigateToSetting -> navigateToSetting()
-            is HomeSideEffect.ShowToast -> {
-                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
-            }
-
+            HomeSideEffect.NavigateToSchedule -> navigateToSchedule()
+            is HomeSideEffect.ShowToast -> Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
             HomeSideEffect.NavigateToLogin -> navigateToLogin()
-            is HomeSideEffect.NavigateToNoticeDetail -> navigateToNoticeDetail(effect.noticeId)
         }
     }
 
@@ -72,7 +65,7 @@ fun HomeScreen(
                     .background(brush = Brush.horizontalGradient(colorStops = colorSteps)),
                 sessions = homeState.sessions,
                 upcomingSessionId = homeState.upcomingSessionId,
-                onClickSessionItem = { }
+                onClickShowAll = { onIntent(HomeIntent.ClickShowAllSession) },
             )
 
             HomeAttendanceNotice(title = homeState.attendanceTitle)
@@ -109,9 +102,7 @@ private fun HomeScreenPreview() {
     YappTheme {
         HomeRoute(
             navigateToLogin = {},
-            navigateToNotice = {},
-            navigateToSetting = {},
-            navigateToNoticeDetail = {}
+            navigateToSchedule = {}
         )
     }
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeViewModel.kt
@@ -62,7 +62,6 @@ internal class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             runCatchingIgnoreCancelled {
                 val result = sessionsUseCase.invoke()
-                val upcomingSessions = result.upcomingSessionInfo
                 val sessions = result.sessions.sessions
 
                 reduce {

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeViewModel.kt
@@ -35,9 +35,8 @@ internal class HomeViewModel @Inject constructor(
         postSideEffect: (HomeSideEffect) -> Unit,
     ) {
         when (intent) {
-            HomeIntent.ClickMoreButton -> postSideEffect(HomeSideEffect.NavigateToNotice)
-            HomeIntent.ClickSettingButton -> postSideEffect(HomeSideEffect.NavigateToSetting)
             HomeIntent.EnterHomeScreen -> { loadHomeInfo( reduce,postSideEffect)  }
+            HomeIntent.ClickShowAllSession -> postSideEffect(HomeSideEffect.NavigateToSchedule)
             HomeIntent.ClickRequestAttendCode -> {
                 reduce {
                     copy(showAttendCodeBottomSheet = true)
@@ -51,7 +50,6 @@ internal class HomeViewModel @Inject constructor(
             is HomeIntent.ClickRequestAttendance -> {
                 requestAttendance(intent.sessionId, intent.code, state, reduce)
             }
-            is HomeIntent.ClickNoticeItem -> postSideEffect(HomeSideEffect.NavigateToNoticeDetail(intent.noticeId))
         }
     }
 

--- a/feature/home/src/main/java/com/yapp/feature/home/component/HomeAttendaceContents.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/component/HomeAttendaceContents.kt
@@ -44,19 +44,21 @@ internal fun HomeAttendanceContents(
 
     Box(
         modifier = modifier
+            .fillMaxWidth()
             .padding(horizontal = 20.dp)
             .dashedBorder(
                 color = Color(0xFFFED9CB),
                 dashLength = 3.dp,
                 cornerRadius = 10.dp
-            ).padding(20.dp)
+            )
+            .padding(20.dp)
     ) {
         if (todayOrUpcomingSession == null) {
             Text(
                 text = "모든 세션이 종료되었어요.\n기수 활동에 참여해 주셔서 감사합니다 :)",
                 textAlign = TextAlign.Center,
                 style = YappTheme.typography.caption1Medium,
-                color = YappTheme.colorScheme.interactionInactive,
+                color = YappTheme.colorScheme.labelNormal,
             )
         } else {
             val sessionDate = runCatching {
@@ -95,20 +97,23 @@ private fun UpcomingSessionCard(
         Text(
             text = "오늘은 ${today.format(dateFormatter)}이에요.",
             style = YappTheme.typography.label2Medium,
-            color = Color.Black
+            color = YappTheme.colorScheme.labelNormal
         )
 
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(Color(0xFFF4F4F4), shape = RoundedCornerShape(12.dp))
+                .background(
+                    color = YappTheme.colorScheme.interactionDisable,
+                    shape = RoundedCornerShape(12.dp)
+                )
                 .padding(vertical = 12.dp),
             contentAlignment = Alignment.Center
         ) {
             Text(
                 text = "${upcomingDate.format(dateFormatter)} 세션예정",
                 style = YappTheme.typography.body2NormalBold,
-                color = Color.Gray
+                color = YappTheme.colorScheme.labelAssistive
             )
         }
     }

--- a/feature/home/src/main/java/com/yapp/feature/home/component/HomeContentsBody.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/component/HomeContentsBody.kt
@@ -3,6 +3,7 @@ package com.yapp.feature.home.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.yapp.core.designsystem.theme.YappTheme
@@ -25,28 +27,42 @@ internal fun HomeAttendanceNotice(
     modifier: Modifier = Modifier,
     title: String
 ) {
-    Column(
-        modifier = modifier.fillMaxWidth()
-            .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
-            .background(YappTheme.colorScheme.staticWhite)
+    val colorSteps = arrayOf(
+        0.2f to YappTheme.colorScheme.primaryNormal,
+        1f to YappTheme.colorScheme.secondaryNormal
+    )
+
+    Box(
+        modifier = Modifier.background(brush = Brush.horizontalGradient(colorStops = colorSteps))
     ) {
-        Spacer(modifier = Modifier.height(24.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth()
-                .padding(horizontal = 20.dp)
-                .background(
-                    color = YappTheme.colorScheme.orange99,
-                    shape = RoundedCornerShape(size = 10.dp)
-                ),
-            horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.CenterVertically
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                .background(YappTheme.colorScheme.staticWhite)
         ) {
-            Image(
-                painter = painterResource(coreDesignR.drawable.home_attandance),
-                contentDescription = null
-            )
-            Text(title, style = YappTheme.typography.label1NormalMedium)
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .background(
+                        color = YappTheme.colorScheme.orange99,
+                        shape = RoundedCornerShape(size = 10.dp)
+                    )
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Image(
+                    painter = painterResource(coreDesignR.drawable.home_attandance),
+                    contentDescription = null
+                )
+                Text(title, style = YappTheme.typography.label1NormalMedium)
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
         }
-        Spacer(modifier = Modifier.height(12.dp))
     }
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/component/HomeHeader.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/component/HomeHeader.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.launch
 import com.yapp.core.designsystem.R as coreDesignR
 
 @Composable
-internal fun HomeStickHeader(
+internal fun HomeHeader(
     modifier: Modifier = Modifier,
     sessions: List<HomeState.Session>,
     upcomingSessionId: String,
@@ -128,6 +128,8 @@ internal fun HomeStickHeader(
             }
         }
 
+        Spacer(modifier = Modifier.height(16.dp))
+
         Indicators(
             itemCount = sessions.size,
             onPageSelect = { index ->
@@ -137,6 +139,8 @@ internal fun HomeStickHeader(
             },
             currentPage = selectedIndex
         )
+
+        Spacer(modifier = Modifier.height(16.dp))
     }
 
     LaunchedEffect(pageIndex) {
@@ -226,7 +230,7 @@ private fun HomeStickHeaderPreview() {
         1f to YappTheme.colorScheme.secondaryNormal
     )
 
-    HomeStickHeader(
+    HomeHeader(
         modifier = Modifier.background(brush = Brush.horizontalGradient(colorStops = colorStops)),
         sessions = listOf(
             HomeState.Session(

--- a/feature/home/src/main/java/com/yapp/feature/home/component/HomeHeader.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/component/HomeHeader.kt
@@ -49,7 +49,7 @@ internal fun HomeHeader(
     modifier: Modifier = Modifier,
     sessions: List<HomeState.Session>,
     upcomingSessionId: String,
-    onClickSessionItem: (String) -> Unit
+    onClickShowAll: () -> Unit,
 ) {
     val pageIndex = sessions.indexOfFirst { it.id == upcomingSessionId }
     val scope = rememberCoroutineScope()
@@ -78,7 +78,9 @@ internal fun HomeHeader(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
@@ -98,13 +100,16 @@ internal fun HomeHeader(
             }
 
             Text(
+                modifier = Modifier.yappClickable(onClick = onClickShowAll),
                 text = stringResource(R.string.home_session_all_title),
                 style = YappTheme.typography.label1NormalBold,
                 color = YappTheme.colorScheme.staticWhite
             )
         }
         LazyRow(
-            modifier = Modifier.fillMaxWidth().padding(top = 10.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp),
             state = lazyListState,
             flingBehavior = flingBehavior,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -123,7 +128,7 @@ internal fun HomeHeader(
                     endTime = it.endTime,
                     startDayOfWeek = it.startDayOfWeek,
                     progressPhase = it.progressPhase,
-                    onClickSessionItem = onClickSessionItem
+                    onClickSessionItem = {  }
                 )
             }
         }
@@ -244,7 +249,7 @@ private fun HomeStickHeaderPreview() {
                 progressPhase = ScheduleProgressPhase.TODAY
             )
         ),
-        onClickSessionItem = {},
+        onClickShowAll = { },
         upcomingSessionId = "123"
     )
 }

--- a/feature/home/src/main/java/com/yapp/feature/home/component/Indicator.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/component/Indicator.kt
@@ -3,7 +3,6 @@ package com.yapp.feature.home.component
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
@@ -42,8 +41,8 @@ internal fun Indicators(
     dotSize: Dp = 8.dp,
     selectedDotSize: Dp = 8.dp,
     dotSpacing: Dp = 8.dp,
-    activeColor: Color = YappTheme.colorScheme.labelNormal,
-    inactiveColor: Color = YappTheme.colorScheme.labelNormal.copy(alpha = 0.16f)
+    activeColor: Color = YappTheme.colorScheme.staticWhite,
+    inactiveColor: Color = YappTheme.colorScheme.staticWhite.copy(alpha = 0.16f)
 ) {
     val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
@@ -95,7 +94,6 @@ internal fun Indicators(
                         }
                     )
                 }
-                .padding(8.dp)
                 .widthIn(max = (visibleDotCount * (dotSize + dotSpacing)).coerceAtLeast(60.dp)),
             horizontalArrangement = Arrangement.spacedBy(dotSpacing),
             verticalAlignment = Alignment.CenterVertically

--- a/feature/home/src/main/java/com/yapp/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/navigation/HomeNavigation.kt
@@ -23,19 +23,13 @@ fun NavController.navigateToSetting(navOptions: NavOptions? = null) {
 }
 
 fun NavGraphBuilder.homeNavGraph(
-    navigateNotice: () -> Unit,
-    navigateSetting: () -> Unit,
     navigateLogin : () -> Unit,
-    navigateToNoticeDetail: (String) -> Unit
+    navigateSchedule: () -> Unit,
 ) {
     composable<HomeRoute> {
         HomeRoute(
-            navigateToNotice = navigateNotice,
-            navigateToSetting = navigateSetting,
             navigateToLogin = navigateLogin,
-            navigateToNoticeDetail = { noticeId ->
-                navigateToNoticeDetail(noticeId)
-            }
+            navigateToSchedule = navigateSchedule,
         )
     }
 }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #156 

## 🌱 Key changes
<!--변경사항 적기-->

피그마 디자인과 비교해서 자잘하게 다른 부분을 수정했습니다

- 세션 헤더 밑에 컴포넌트 TopRoundedCorner 적용
- 컴포넌트간 간격 수정
- 글꼴 및 색상값 적용
- 세션 헤더 전체 보기 클릭 시 일정 탭으로 이동

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

세션 상태값마다의 디자인 (당일, 임박, 예정 등)
출석 상태에 따른 디자인 (진행 중, 출석 가능) 등은 따로 테스트를 하기가 힘들어서 QA 때 따로 잡아야할 것 같습니다.

## 📸 스크린샷

https://github.com/user-attachments/assets/940090d4-6643-49af-9306-b74251a9386c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 홈 화면에서 모든 세션을 한 번에 볼 수 있는 "전체 세션 보기" 기능이 추가되었습니다.

- **기능 개선**
    - 홈 화면 상단 영역이 새롭게 개선되어, 세션 목록 우측의 "전체 보기" 버튼 클릭 시 일정 화면으로 이동합니다.
    - 공지사항 및 설정 화면으로의 이동 기능이 제거되고, 일정 화면으로 바로 이동하는 내비게이션이 적용되었습니다.
    - 홈 화면 내 세션/출석 관련 UI가 더 넓게 표시되고, 컬러가 일관된 테마 색상으로 변경되었습니다.
    - 출석 안내 영역에 그라데이션 배경이 추가되어 시각적 효과가 향상되었습니다.

- **스타일**
    - 세션 인디케이터(점) 색상이 흰색으로 변경되었습니다.
    - 일부 레이아웃의 패딩 및 여백이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->