### PR TITLE
Feature/#159 : 사용자가 출석체크 코드 백버튼 제거 시 이전 텍스트 필드로 포커싱 가도록 처리

### DIFF
--- a/feature/home/src/main/java/com/yapp/feature/home/dialog/AttendanceDialog.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/dialog/AttendanceDialog.kt
@@ -139,9 +139,8 @@ private fun PinCodeInput(
                     .size(60.dp)
                     .focusRequester(focusRequesters[index])
                     .onKeyEvent {
-                        if (it.key == Key.Backspace && it.type == KeyEventType.KeyDown && values[index].isEmpty()) {
+                        if (it.key == Key.Backspace && it.type == KeyEventType.KeyUp && values[index].isEmpty()) {
                             if (index > 0) {
-                                onValueChange(index - 1, "")
                                 focusRequesters[index - 1].requestFocus()
                             }
                             true

--- a/feature/home/src/main/java/com/yapp/feature/home/dialog/AttendanceDialog.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/dialog/AttendanceDialog.kt
@@ -16,6 +16,8 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -48,7 +50,11 @@ internal fun AttendanceDialog(
     val codeLength = 4
     val values = remember { mutableStateListOf("", "", "", "") }
     val focusRequesters = remember { List(codeLength) { FocusRequester() } }
-    val isAllValuesEntered = remember(values) { values.all { it.isNotEmpty() } }
+    val isAllValuesEntered by remember(values) {
+        derivedStateOf {
+            values.all { it.isNotEmpty() }
+        }
+    }
 
     BottomDialog(
         onDismissRequest = onDismissRequest,

--- a/feature/home/src/main/java/com/yapp/feature/home/dialog/AttendanceDialog.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/dialog/AttendanceDialog.kt
@@ -11,10 +11,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -56,55 +59,62 @@ internal fun AttendanceDialog(
         }
     }
 
-    BottomDialog(
-        onDismissRequest = onDismissRequest,
-        content = {
-            Column(
-                modifier = Modifier
-                    .padding(20.dp)
-                    .background(
-                        color = YappTheme.colorScheme.staticWhite,
-                        shape = RoundedCornerShape(20.dp)
-                    )
-            ) {
-                Text(
-                    text = stringResource(R.string.attendance_dialog_title),
-                    style = YappTheme.typography.headline1Bold
-                )
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    text = stringResource(R.string.attendance_dialog_message),
-                    style = YappTheme.typography.label1ReadingRegular
-                )
-                Spacer(Modifier.height(24.dp))
-
-                PinCodeInput(
-                    values = values,
-                    onValueChange = { index, value -> values[index] = value },
-                    focusRequesters = focusRequesters,
-                    isAllValuesEntered = isAllValuesEntered
-                )
-
-                Spacer(Modifier.height(24.dp))
-
-                YappSolidPrimaryButtonLarge(
-                    modifier = Modifier.fillMaxWidth(),
-                    enable = values.all { it.isNotEmpty() && it.all { it.isDigit() } },
-                    onClick = { clickAttendanceButton(values.joinToString(separator = "")) },
-                    text = stringResource(R.string.attendance_dialog_confirm_button)
-                )
-
-                Spacer(Modifier.height(8.dp))
-
-                YappTextPrimaryButtonSmall(
-                    modifier = Modifier.fillMaxWidth(),
-                    enable = true,
-                    text = stringResource(R.string.attendance_dialog_cancel_button),
-                    onClick = { onDismissRequest() }
-                )
-            }
-        }
+    val yappTextSelectionColors = TextSelectionColors(
+        handleColor = YappTheme.colorScheme.primaryNormal, // 물방울 모양 핸들의 색상
+        backgroundColor = YappTheme.colorScheme.primaryNormal // 선택된 텍스트의 배경색
     )
+
+    CompositionLocalProvider(LocalTextSelectionColors provides yappTextSelectionColors) {
+        BottomDialog(
+            onDismissRequest = onDismissRequest,
+            content = {
+                Column(
+                    modifier = Modifier
+                        .padding(20.dp)
+                        .background(
+                            color = YappTheme.colorScheme.staticWhite,
+                            shape = RoundedCornerShape(20.dp)
+                        )
+                ) {
+                    Text(
+                        text = stringResource(R.string.attendance_dialog_title),
+                        style = YappTheme.typography.headline1Bold
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.attendance_dialog_message),
+                        style = YappTheme.typography.label1ReadingRegular
+                    )
+                    Spacer(Modifier.height(24.dp))
+
+                    PinCodeInput(
+                        values = values,
+                        onValueChange = { index, value -> values[index] = value },
+                        focusRequesters = focusRequesters,
+                        isAllValuesEntered = isAllValuesEntered
+                    )
+
+                    Spacer(Modifier.height(24.dp))
+
+                    YappSolidPrimaryButtonLarge(
+                        modifier = Modifier.fillMaxWidth(),
+                        enable = values.all { it.isNotEmpty() && it.all { it.isDigit() } },
+                        onClick = { clickAttendanceButton(values.joinToString(separator = "")) },
+                        text = stringResource(R.string.attendance_dialog_confirm_button)
+                    )
+
+                    Spacer(Modifier.height(8.dp))
+
+                    YappTextPrimaryButtonSmall(
+                        modifier = Modifier.fillMaxWidth(),
+                        enable = true,
+                        text = stringResource(R.string.attendance_dialog_cancel_button),
+                        onClick = { onDismissRequest() }
+                    )
+                }
+            }
+        )
+    }
 }
 
 @Composable
@@ -157,11 +167,12 @@ private fun PinCodeInput(
                 shape = RoundedCornerShape(12.dp),
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = YappTheme.colorScheme.primaryNormal,
-                    unfocusedBorderColor = YappTheme.colorScheme.labelNormal
+                    unfocusedBorderColor = YappTheme.colorScheme.labelNormal,
+                    cursorColor = YappTheme.colorScheme.primaryNormal,
                 ),
                 keyboardOptions = KeyboardOptions.Default.copy(
                     keyboardType = KeyboardType.Number
-                )
+                ),
             )
         }
     }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #159

## 🌱 Key changes
- 사용자가 출석체크 코드 백버튼 제거 시 이전 텍스트 필드로 포커싱 가도록 처리
- 불필요한 리멤버 계산으로 인한 derivedStateOf 추가

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


https://github.com/user-attachments/assets/6d1bedfc-e80c-4ed7-b7d0-50b069a113dc

테스트 기기가 없어서 가상 머신으로 영상 첨부했습니다




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 입력 값이 변경될 때 `isAllValuesEntered` 상태가 자동으로 업데이트되도록 개선되었습니다.
  - 핀 코드 입력 시 백스페이스 키 동작이 수정되어, 이제 키를 뗄 때만 이전 입력란으로 포커스가 이동하며 기존 값은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->