### PR TITLE
chore/#173: firebase 및 crashlytics 버전 업데이트

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,8 @@ activityCompose = "1.9.3"
 compose-stable-marker = "1.0.3"
 
 composeBom = "2024.12.01"
-firebaseBom = "32.1.1"
-firebaseCrashlytics = "2.9.9"
+firebaseBom = "33.13.0"
+firebaseCrashlytics = "3.0.3"
 coroutinesPlayServices = "1.7.3"
 
 junit = "4.13.2"


### PR DESCRIPTION
firebaseBom을 32.1.1에서 33.13.0으로, firebaseCrashlytics를 2.9.9에서 3.0.3으로 업데이트합니다.

## 💡 Issue
- Resolved: #173 

## 🌱 Key changes
<!--변경사항 적기-->

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|
