### PR TITLE
Bugfix/#181 공지사항이 순서대로 안 불러와지는 현상 수정

### DIFF
--- a/core/ui/src/main/java/com/yapp/core/ui/component/YappBackground.kt
+++ b/core/ui/src/main/java/com/yapp/core/ui/component/YappBackground.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.onConsumedWindowInsetsChanged
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -21,7 +21,7 @@ import com.yapp.core.designsystem.theme.YappTheme
 fun YappBackground(
     modifier: Modifier = Modifier,
     color: Color = YappTheme.colorScheme.backgroundElevatedNormal,
-    contentWindowInsets: WindowInsets = WindowInsets.systemBars,
+    contentWindowInsets: WindowInsets = WindowInsets.statusBars,
     content: @Composable () -> Unit,
 ) {
     val safeInsets = remember(contentWindowInsets) {
@@ -35,7 +35,6 @@ fun YappBackground(
         modifier = modifier
             .fillMaxSize()
             .onConsumedWindowInsetsChanged { consumedWindowInsets ->
-                // Exclude currently consumed window insets from user provided contentWindowInsets
                 safeInsets.insets = contentWindowInsets.exclude(consumedWindowInsets)
             }
             .padding(safeInsets.insets.asPaddingValues()),

--- a/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeViewModel.kt
+++ b/feature/notice/src/main/java/com/yapp/feature/notice/notice/NoticeViewModel.kt
@@ -10,10 +10,8 @@ import com.yapp.model.NoticeType
 import com.yapp.model.exceptions.InvalidTokenException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -64,7 +62,7 @@ class NoticeViewModel @Inject constructor(
             .onEach { noticeList ->
                 reduce {
                     copy(
-                        notices = noticeList.copy(notices = noticeList.notices + state.notices.notices),
+                        notices = noticeList.copy(notices = state.notices.notices + noticeList.notices),
                         isNoticesLoading = false
                     )
                 }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #181 

## 🌱 Key changes
<!--변경사항 적기-->
- 새로 불러온 공지사항을 하단에 추가하도록 수정
- YappBackground 하단 여백 제거

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|![image](https://github.com/user-attachments/assets/f7651b06-fe3d-4950-b7d4-7183d45bc0f7)|
