### PR TITLE
QA : 이전 출석 내역 컴포넌트 간 vertical 스페이싱 처리 되어 있지 않는 현상 수정

### DIFF
--- a/feature/history/src/main/java/com/yapp/feature/history/previous/PreviousHistoryScreen.kt
+++ b/feature/history/src/main/java/com/yapp/feature/history/previous/PreviousHistoryScreen.kt
@@ -89,7 +89,10 @@ private fun PreviousHistoryScreen(
                         generation = item.generation,
                         slot = {
                             if (item.showSlot) {
-                                Text("${item.activityStartDate} - ${item.activityEndDate}")
+                                Text(
+                                    text = "${item.activityStartDate} - ${item.activityEndDate}",
+                                    style = YappTheme.typography.label2Regular.copy(color = YappTheme.colorScheme.lineNormalStrong)
+                                )
                             }
                         }
                     )

--- a/feature/history/src/main/java/com/yapp/feature/history/previous/PreviousHistoryScreen.kt
+++ b/feature/history/src/main/java/com/yapp/feature/history/previous/PreviousHistoryScreen.kt
@@ -2,6 +2,7 @@ package com.yapp.feature.history.previous
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
@@ -75,7 +76,8 @@ private fun PreviousHistoryScreen(
 
             LazyColumn(
                 modifier = Modifier.weight(1f),
-                contentPadding = PaddingValues(20.dp)
+                contentPadding = PaddingValues(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 items(items) { item ->
                     HistoryItems(

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -2,7 +2,6 @@ import com.yapp.app.setNamespace
 
 plugins {
     id("yapp.android.feature")
-    id("yapp.android.hilt")
 }
 
 android {


### PR DESCRIPTION
## 💡 Issue

## 🌱 Key changes
- 이전 출석내역 vertical spacing 처리를 추가했습니다.
- 이전 출석내역 기간 텍스트 뷰에 타이포그래피 및 색상이 적용되어 있지 않아서 추가했습니다.

## ✅ To Reviewers
<img src = "https://github.com/user-attachments/assets/8654353f-1c13-4bb2-9a8a-c569fc82d9ae" width = 200>

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


