### PR TITLE
feat/#189: 가입 신청 시 버튼 비활성화 처리

### DIFF
--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpContract.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpContract.kt
@@ -11,10 +11,12 @@ data class SignUpState(
     val signUpCode: String = "",
     val signUpErrorInputTextDescription: String? = null,
     val positions: List<String> = emptyList(),
+    private val isSignUpRequesting: Boolean = false,
 ) {
     val showKeyboardAboveButton = currentStep != SignUpStep.Position
     val showSignUpScreenButton: Boolean = showSignUpCodeBottomDialog.not()
-    val inputCompleteButtonEnable = signUpCode.isNotBlank()
+    val noSignUpCodeButtonEnable: Boolean = isSignUpRequesting.not()
+    val inputCompleteButtonEnable = signUpCode.isNotBlank() && isSignUpRequesting.not()
     val isSignUpErrorInputTextError = signUpErrorInputTextDescription != null
     val backIcon: Int? = when (currentStep) {
         SignUpStep.Complete -> null

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpScreen.kt
@@ -176,6 +176,7 @@ fun SignUpScreen(
                 inputCompleteButtonEnable = uiState.inputCompleteButtonEnable,
                 isSignUpCodeInputTextError = uiState.isSignUpErrorInputTextError,
                 signUpCodeInputTextDescription = uiState.signUpErrorInputTextDescription,
+                noSignUpCodeButtonEnable = uiState.noSignUpCodeButtonEnable,
                 onSignUpCodeChange = { onIntent(SignUpIntent.ChangeSignUpCode(it)) },
                 onInputCompleteButtonClick = { onIntent(SignUpIntent.ClickInputCompleteButton) },
                 onNoSignUpCodeButtonClick = { onIntent(SignUpIntent.ClickNoSignUpCodeButton) },

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/SignUpViewModel.kt
@@ -210,6 +210,7 @@ class SignUpViewModel @Inject constructor(
         postSideEffect: (SignUpSideEffect) -> Unit,
     ) = viewModelScope.launch {
         postSideEffect(SignUpSideEffect.ClearFocus) // FIXME: TextField가 Focus를 가진 상태로 BottomSheet가 사라지면, 시스템 뒤로가기 이벤트가 동작하지 않는 문제가 있음
+        reduce { copy(isSignUpRequesting = true) }
 
         signUpUseCase(signUpInfo)
             .onSuccess { result ->
@@ -236,6 +237,7 @@ class SignUpViewModel @Inject constructor(
                     }
                 }
             }
+        reduce { copy(isSignUpRequesting = false) }
     }
 
     private fun getPrimaryButtonEnable(step: SignUpStep): Boolean {

--- a/feature/signup/src/main/java/com/yapp/feature/signup/signup/component/SignUpCodeBottomDialog.kt
+++ b/feature/signup/src/main/java/com/yapp/feature/signup/signup/component/SignUpCodeBottomDialog.kt
@@ -23,6 +23,7 @@ fun SignUpCodeBottomDialog(
     inputCompleteButtonEnable: Boolean,
     isSignUpCodeInputTextError: Boolean,
     signUpCodeInputTextDescription: String?,
+    noSignUpCodeButtonEnable: Boolean,
     onDismissRequest: () -> Unit,
     onSignUpCodeChange: (String) -> Unit,
     onInputCompleteButtonClick: () -> Unit,
@@ -64,6 +65,7 @@ fun SignUpCodeBottomDialog(
 
             YappTextPrimaryButtonSmall(
                 modifier = Modifier.fillMaxWidth(),
+                enable = noSignUpCodeButtonEnable,
                 text = stringResource(R.string.signup_code_bottom_dialog_no_code_button),
                 onClick = onNoSignUpCodeButtonClick
             )


### PR DESCRIPTION
## 💡 Issue
- Resolved: #189

## 🌱 Key changes
<!--변경사항 적기-->
- 가입 신청 버튼 클릭 시 중복 클릭을 방지하기 위해 버튼을 비활성화 처리합니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷

https://github.com/user-attachments/assets/65987608-2382-4c46-a87b-7ce1a56067ce



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 회원가입 요청 중일 때 버튼 활성화 상태가 변경되어, "회원가입 코드 없음" 버튼과 "입력 완료" 버튼이 요청 진행 중에는 비활성화됩니다.
- **버그 수정**
    - 회원가입 요청이 진행 중일 때 중복 요청을 방지하기 위해 관련 버튼들이 비활성화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->