### PR TITLE
fix/#195: 앱 기본 폰트 크기 1.0f로 고정

### DIFF
--- a/app/src/main/java/com/yapp/app/official/MainActivity.kt
+++ b/app/src/main/java/com/yapp/app/official/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.yapp.app.official
 
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -133,4 +135,13 @@ class MainActivity : ComponentActivity() {
             requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
         }
     }
+
+    override fun attachBaseContext(newBase: Context) {
+        val config = Configuration(newBase.resources.configuration).apply {
+            fontScale = 1f
+        }
+        val context = newBase.createConfigurationContext(config)
+        super.attachBaseContext(context)
+    }
+
 }

--- a/app/src/main/java/com/yapp/app/official/YappOfficialApplication.kt
+++ b/app/src/main/java/com/yapp/app/official/YappOfficialApplication.kt
@@ -1,8 +1,6 @@
 package com.yapp.app.official
 
 import android.app.Application
-import android.content.Context
-import android.content.res.Configuration
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
@@ -15,13 +13,5 @@ class YappOfficialApplication : Application() {
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
-    }
-
-    // 앱 기본 폰트 크기를 1.0f로 고정합니다.
-    override fun attachBaseContext(base: Context?) {
-        val configuration = Configuration(base?.resources?.configuration)
-        configuration.fontScale = 1.0f
-        val context = base?.createConfigurationContext(configuration)
-        super.attachBaseContext(context)
     }
 }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #195

## 🌱 Key changes
<!--변경사항 적기-->
- 시스템 폰트를 키워도 앱의 폰트 크기에는 반영되지 않도록 설정했습니다.
- 접근성은 떨어지지만, YAPP의 회원이 2~30대임을 감안했을 때 문제 없을거라 판단했습니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 앱의 글꼴 크기가 시스템 설정과 무관하게 고정되도록 변경되었습니다. 이제 시스템 글꼴 크기 조정이 앱 내 텍스트에 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->