### PR TITLE
Feature/#194: 출석 완료 상태에 따라 버튼 노출 메세지 변경

### DIFF
--- a/feature/home/src/main/java/com/yapp/feature/home/component/HomeAttendanceContent.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/component/HomeAttendanceContent.kt
@@ -29,6 +29,7 @@ import com.yapp.core.designsystem.theme.YappTheme
 import com.yapp.core.ui.extension.dashedBorder
 import com.yapp.core.ui.util.formatToKoreanTime
 import com.yapp.feature.home.R
+import com.yapp.model.AttendanceStatus
 import com.yapp.model.UpcomingSessionInfo
 import java.time.LocalDate
 import java.time.LocalTime
@@ -55,13 +56,7 @@ internal fun HomeAttendanceContent(
             .padding(20.dp)
     ) {
         if (upcomingSession == null) {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(id = R.string.session_ended_message),
-                textAlign = TextAlign.Center,
-                style = YappTheme.typography.caption1Medium,
-                color = YappTheme.colorScheme.labelNormal,
-            )
+            EmptySessionMessage()
         } else {
             if (isToday) {
                 TodaySessionCard(
@@ -76,6 +71,17 @@ internal fun HomeAttendanceContent(
             }
         }
     }
+}
+
+@Composable
+private fun EmptySessionMessage() {
+    Text(
+        modifier = Modifier.fillMaxWidth(),
+        text = stringResource(id = R.string.session_ended_message),
+        textAlign = TextAlign.Center,
+        style = YappTheme.typography.caption1Medium,
+        color = YappTheme.colorScheme.labelNormal,
+    )
 }
 
 @Composable
@@ -174,10 +180,18 @@ fun TodaySessionCard(
             }
         }
 
-        if (isAttended) {
+        session.status?.let { status ->
+            val message = when (status) {
+                AttendanceStatus.ATTENDED -> stringResource(R.string.session_attendance_done)
+                AttendanceStatus.LATE -> stringResource(R.string.session_attendance_late)
+                AttendanceStatus.ABSENT -> stringResource(R.string.session_attendance_absent)
+                AttendanceStatus.EARLY_LEAVE -> stringResource(R.string.session_attendance_early_leave)
+                AttendanceStatus.EXCUSED -> stringResource(R.string.session_attendance_excused)
+            }
+
             YappSolidPrimaryButtonLarge(
                 modifier = Modifier.fillMaxWidth(),
-                text = stringResource(R.string.session_attendance_done),
+                text = message,
                 enable = false,
                 colors = SolidButtonDefaults.colorsPrimary.copy(
                     disableBackgroundColor = YappTheme.colorScheme.orange99,
@@ -185,22 +199,19 @@ fun TodaySessionCard(
                 ),
                 onClick = {}
             )
-        } else {
-            if (session.canCheckIn) {
-                YappSolidPrimaryButtonLarge(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(R.string.session_attendance),
-                    enable = true,
-                    onClick = onClickAttend
-                )
+        } ?: run {
+            val buttonText = if (session.canCheckIn) {
+                stringResource(R.string.session_attendance)
             } else {
-                YappSolidPrimaryButtonLarge(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(R.string.session_attendance_not_yet_message),
-                    enable = false,
-                    onClick = {}
-                )
+                stringResource(R.string.session_attendance_not_yet_message)
             }
+
+            YappSolidPrimaryButtonLarge(
+                modifier = Modifier.fillMaxWidth(),
+                text = buttonText,
+                enable = session.canCheckIn,
+                onClick = { if (session.canCheckIn) onClickAttend() },
+            )
         }
     }
 }

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -19,6 +19,10 @@
     <string name="session_time_end">%1$s 종료</string>
     <string name="session_time_missing">장소 미정</string>
     <string name="session_attendance_done">출석완료!</string>
+    <string name="session_attendance_late">다음엔 좀 더 일찍 오기!</string>
+    <string name="session_attendance_absent">다음엔 좀 더 일찍 오기!</string>
+    <string name="session_attendance_early_leave">다음엔 끝까지 함께 해요~</string>
+    <string name="session_attendance_excused">다음 세션엔 함께 해요!</string>
     <string name="session_attendance">출석하기</string>
     <string name="session_date_error">날짜 정보를 불러올 수 없어요.</string>
     <string name="session_in_progress">진행중</string>


### PR DESCRIPTION
## 💡 Issue
- Resolved: #194 

## 🌱 Key changes
<!--변경사항 적기-->
출석 완료 상태에 따라 버튼 노출 메세지 변경

출석 -> 출석 완료!
지각, 결석 -> 다음엔 좀 더 일찍 오기!
조퇴 -> 다음엔 끝까지 함께 해요~
공결 -> 다음 세션엔 함께 해요!

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 세션 출석 상태에 따라 다양한 안내 메시지가 버튼에 표시됩니다.
  - 출석 상태별(지각, 결석, 조퇴, 출석 인정) 안내 문구가 추가되었습니다.

- **스타일**
  - 출석 버튼의 활성화 및 비활성화 상태가 더 명확하게 구분되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->