### PR TITLE
[Feature] 세션현황 진행률 소수점 표기

### DIFF
--- a/core/data/src/main/java/com/yapp/core/data/remote/model/response/AttendStatisticsResponse.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/model/response/AttendStatisticsResponse.kt
@@ -1,14 +1,13 @@
 package com.yapp.core.data.remote.model.response
 
 import com.yapp.model.AttendStatistics
-import com.yapp.model.UserInfo
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class AttendStatisticsResponse(
     val totalSessionCount: Int,
     val remainingSessionCount: Int,
-    val sessionProgressRate: Int,
+    val sessionProgressRate: Double,
     val attendancePoint: Int,
     val attendanceCount: Int,
     val lateCount: Int,

--- a/core/model/src/main/java/com/yapp/model/AttendStatistics.kt
+++ b/core/model/src/main/java/com/yapp/model/AttendStatistics.kt
@@ -3,7 +3,7 @@ package com.yapp.model
 data class AttendStatistics(
     val totalSessionCount: Int,
     val remainingSessionCount: Int,
-    val sessionProgressRate: Int,
+    val sessionProgressRate: Double,
     val attendancePoint: Int,
     val attendanceCount: Int,
     val lateCount: Int,

--- a/feature/history/src/main/java/com/yapp/feature/history/attend/AttendHistoryContract.kt
+++ b/feature/history/src/main/java/com/yapp/feature/history/attend/AttendHistoryContract.kt
@@ -1,6 +1,7 @@
 package com.yapp.feature.history.attend
 
 import com.yapp.model.AttendanceHistoryList
+import java.text.DecimalFormat
 
 data class AttendHistoryState(
     val totalSessionCount: Int = 0,
@@ -14,7 +15,14 @@ data class AttendHistoryState(
     val attendanceHistoryList: AttendanceHistoryList = AttendanceHistoryList(
         histories = emptyList()
     ),
-)
+) {
+    val formattedSessionProgressRate: String
+        get() = if (sessionProgressRate % 1.0 == 0.0) {
+            "${sessionProgressRate.toInt()}%"
+        } else {
+            "${DecimalFormat("#.#").format(sessionProgressRate)}%"
+        }
+}
 
 sealed interface AttendHistoryIntent {
     data object OnEntryScreen : AttendHistoryIntent

--- a/feature/history/src/main/java/com/yapp/feature/history/attend/AttendHistoryContract.kt
+++ b/feature/history/src/main/java/com/yapp/feature/history/attend/AttendHistoryContract.kt
@@ -5,7 +5,7 @@ import com.yapp.model.AttendanceHistoryList
 data class AttendHistoryState(
     val totalSessionCount: Int = 0,
     val remainingSessionCount: Int = 0,
-    val sessionProgressRate: Int = 0,
+    val sessionProgressRate: Double = 0.0,
     val attendancePoint: Int = 0,
     val attendanceCount: Int = 0,
     val lateCount: Int = 0,
@@ -14,16 +14,7 @@ data class AttendHistoryState(
     val attendanceHistoryList: AttendanceHistoryList = AttendanceHistoryList(
         histories = emptyList()
     ),
-) {
-    val alertMessage: String
-        get() {
-            return if (absenceCount >= 10) {
-                "결석이 10번 이상이 되면 출결에 문제가 생겨 재적처리가 될 수 있어요. 출석 관리에 조금 더 신경 써 주세요!"
-            } else {
-                ""
-            }
-        }
-}
+)
 
 sealed interface AttendHistoryIntent {
     data object OnEntryScreen : AttendHistoryIntent

--- a/feature/history/src/main/java/com/yapp/feature/history/attend/AttendHistoryScreen.kt
+++ b/feature/history/src/main/java/com/yapp/feature/history/attend/AttendHistoryScreen.kt
@@ -17,8 +17,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yapp.core.designsystem.component.header.YappHeaderActionbar
 import com.yapp.core.designsystem.theme.YappTheme
-import com.yapp.core.ui.extension.collectWithLifecycle
 import com.yapp.core.ui.component.YappBackground
+import com.yapp.core.ui.extension.collectWithLifecycle
 import com.yapp.feature.history.R
 import com.yapp.feature.history.attend.component.AttendanceStatusSection
 import com.yapp.feature.history.attend.component.SessionAttendanceHistory
@@ -63,7 +63,7 @@ internal fun AttendHistoryRoute(
 @Composable
 private fun AttendHistoryScreen(
     attendancePoint: Int,
-    sessionProgressRate: Int,
+    sessionProgressRate: Double,
     totalSessionCount: Int,
     totalRemainSessionCount: Int,
     attendance: Int,

--- a/feature/history/src/main/java/com/yapp/feature/history/attend/AttendHistoryScreen.kt
+++ b/feature/history/src/main/java/com/yapp/feature/history/attend/AttendHistoryScreen.kt
@@ -46,7 +46,7 @@ internal fun AttendHistoryRoute(
 
     AttendHistoryScreen(
         attendancePoint = uiState.attendancePoint,
-        sessionProgressRate = uiState.sessionProgressRate,
+        sessionProgressRate = uiState.formattedSessionProgressRate,
         totalSessionCount = uiState.totalSessionCount,
         totalRemainSessionCount = uiState.remainingSessionCount,
         attendance = uiState.attendanceCount,
@@ -63,7 +63,7 @@ internal fun AttendHistoryRoute(
 @Composable
 private fun AttendHistoryScreen(
     attendancePoint: Int,
-    sessionProgressRate: Double,
+    sessionProgressRate: String,
     totalSessionCount: Int,
     totalRemainSessionCount: Int,
     attendance: Int,
@@ -106,7 +106,7 @@ private fun AttendHistoryScreen(
                         modifier = Modifier.padding(horizontal = 20.dp),
                         title = stringResource(R.string.session_title),
                         subTitle = stringResource(R.string.total_remain_session_progress_rate_title),
-                        totalRate = "${sessionProgressRate}%",
+                        totalRate = sessionProgressRate,
                         slot = {
                             StatusItem(
                                 modifier = Modifier.weight(1f),


### PR DESCRIPTION
## 💡 Issue
- Resolved: #204 

## 🌱 Key changes
<!--변경사항 적기-->
- 세션 진행률을 소수점 첫째 자리까지 표시 (서버에서 가공해서 내려옴)
- 세션 진행률이 정수일 경우 (e.g., 12.0) 소수점 없이 표시

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|<img width="294" alt="image" src="https://github.com/user-attachments/assets/d7a07e4a-b5ce-4323-b5f0-2d5da41a863a" />|
