### PR TITLE
[Feature] 이번 기수 세션 -> 이번 달 세션 조회로 변경

### DIFF
--- a/core/common-android/src/main/java/com/yapp/core/common/android/util/DateUtil.kt
+++ b/core/common-android/src/main/java/com/yapp/core/common/android/util/DateUtil.kt
@@ -1,0 +1,10 @@
+package com.yapp.core.common.android.util
+
+import java.time.LocalDate
+
+fun LocalDate.toMonthDateRange(): Pair<String, String> {
+    val startOfMonth = this.withDayOfMonth(1)
+    val endOfMonth = this.withDayOfMonth(this.lengthOfMonth())
+
+    return Pair(startOfMonth.toString(), endOfMonth.toString())
+}

--- a/core/data-api/src/main/java/com/yapp/dataapi/ScheduleRepository.kt
+++ b/core/data-api/src/main/java/com/yapp/dataapi/ScheduleRepository.kt
@@ -5,7 +5,7 @@ import com.yapp.model.ScheduleList
 import com.yapp.model.UpcomingSessionInfo
 
 interface ScheduleRepository {
-    suspend fun getSessions(): HomeSessionList
+    suspend fun getSessions(startDate: String, endDate: String): HomeSessionList
 
     suspend fun getDateGroupedSessions(): ScheduleList
 

--- a/core/data/src/main/java/com/yapp/core/data/data/repository/ScheduleRepositoryImpl.kt
+++ b/core/data/src/main/java/com/yapp/core/data/data/repository/ScheduleRepositoryImpl.kt
@@ -19,8 +19,8 @@ internal class ScheduleRepositoryImpl @Inject constructor(
     private var scheduleCache: MutableMap<Pair<Int, Int>, ScheduleList> = mutableMapOf()
     private var upcomingSessionCache: UpcomingSessionInfo? = null
 
-    override suspend fun getSessions(): HomeSessionList {
-        return scheduleApi.getSessions().toHomeSessionListModel()
+    override suspend fun getSessions(startDate: String, endDate: String): HomeSessionList {
+        return scheduleApi.getSessions(start = startDate, end = endDate).toHomeSessionListModel()
     }
 
     override suspend fun getDateGroupedSessions(): ScheduleList {

--- a/core/data/src/main/java/com/yapp/core/data/remote/api/ScheduleApi.kt
+++ b/core/data/src/main/java/com/yapp/core/data/remote/api/ScheduleApi.kt
@@ -7,8 +7,12 @@ import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface ScheduleApi {
-    @GET("v1/sessions")
-    suspend fun getSessions(): SessionResponse
+    @GET("v2/sessions")
+    suspend fun getSessions(
+        @Query("generation") generation: Int? = null,
+        @Query("start") start: String? = null,
+        @Query("end") end: String? = null
+    ): SessionResponse
 
     @GET("v1/sessions/upcoming")
     suspend fun getUpcomingSession(): UpcomingSessionAttendanceResponse

--- a/feature/home/src/main/java/com/yapp/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/feature/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.yapp.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yapp.core.common.android.record
+import com.yapp.core.common.android.util.toMonthDateRange
 import com.yapp.core.ui.mvi.MviIntentStore
 import com.yapp.core.ui.mvi.mviIntentStore
 import com.yapp.dataapi.AttendanceRepository
@@ -18,6 +19,7 @@ import com.yapp.model.exceptions.NoScheduledSessionException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -101,9 +103,11 @@ internal class HomeViewModel @Inject constructor(
         reduce: (HomeState.() -> HomeState) -> Unit,
         postSideEffect: (HomeSideEffect) -> Unit
     ) = viewModelScope.launch {
+        val (startDate, endDate) = LocalDate.now().toMonthDateRange()
+
         reduce { copy(isLoading = true) }
         runCatchingIgnoreCancelled {
-            scheduleRepository.getSessions()
+            scheduleRepository.getSessions(startDate, endDate)
         }.onSuccess { homeSessions ->
             reduce {
                 copy(
@@ -118,7 +122,6 @@ internal class HomeViewModel @Inject constructor(
         }
         reduce { copy(isLoading = false) }
     }
-
 
     private fun loadUpcomingSessionInfo(
         reduce: (HomeState.() -> HomeState) -> Unit,


### PR DESCRIPTION
## 💡 Issue
- Resolved: #209 

## 🌱 Key changes
<!--변경사항 적기-->
- 홈 화면에서 이번 기수 -> 이번 달 세션 조회를 하도록 변경
- 월 범위 반환 LocalDate 확장 함수 추가

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
이번달 세션을 불러오기 위해서는 월의 시작일과 종료일을 query paremter로 전달해야 했습니다.
Repository의 경우 DataSource 접근만 책임지며, UseCase에는 안드로이드 종속성이 들어갈 수 없기 때문에 ViewModel에서 이를 계산하도록 했습니다.
기존에 날짜 관련 유틸 함수가 ui 모듈의 util 패키지에도 존재했지만, 해당 함수는 UI와 무관한 순수 날짜 계산 기능이므로 androidCommon 모듈에 선언했습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/43997345-2db1-48c4-ba30-37e309c6d12b" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 세션 정보를 월별로 조회할 수 있도록 월의 시작일과 종료일 기준으로 세션을 불러오는 기능이 추가되었습니다.

* **기능 개선**
  * 세션 목록 조회 시 날짜 범위(시작일, 종료일)를 지정하여 더 정확한 데이터 조회가 가능해졌습니다.
  * 세션 API가 새로운 버전(v2)으로 업데이트되어, 세대 및 날짜 필터링이 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->