### PR TITLE
[Feature] 일정탭 UI 변경 및 상세 이동 기능 구현

### DIFF
--- a/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
+++ b/app/src/main/java/com/yapp/app/official/navigation/YappNavHost.kt
@@ -86,6 +86,9 @@ fun YappNavHost(
                 )
             },
             handleException = handleException,
+            navigateToSessionDetail = { sessionId ->
+                navigator.navigateSessionScreen(sessionId)
+            }
         )
         noticeNavGraph(
             navigateToNoticeDetail = { noticeId ->

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleContract.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleContract.kt
@@ -20,11 +20,13 @@ sealed interface ScheduleIntent {
     data class RefreshTab(val tab: ScheduleTab): ScheduleIntent
     data object ClickPreviousMonth: ScheduleIntent
     data object ClickNextMonth: ScheduleIntent
+    data class ClickSessionItem(val id: String): ScheduleIntent
 }
 
 sealed interface ScheduleSideEffect {
     data class HandleException(val exception: Throwable): ScheduleSideEffect
     data object NavigateToLogin: ScheduleSideEffect
+    data class NavigateToSessionDetail(val id: String): ScheduleSideEffect
 }
 
 enum class ScheduleTab(val index: Int, val labelResId: Int) {

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
@@ -189,7 +189,7 @@ private fun ScheduleAllScreen(
         } else {
             itemsIndexed(schedules.dates, key = { _, it -> it.date }) { index, grouped ->
                 DateGroupedScheduleItem(
-                    variant = ScheduleGroupVariant.TOP_ALIGNED,
+                    variant = ScheduleGroupVariant.LEFT_ALIGNED,
                     date = grouped.date,
                     dayOfWeek = grouped.dayOfTheWeek,
                     isToday = grouped.isToday,

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
@@ -56,6 +56,7 @@ internal fun ScheduleRoute(
     viewModel: ScheduleViewModel = hiltViewModel(),
     handleException: (Throwable) -> Unit,
     navigateToLogin: () -> Unit,
+    navigateToSessionDetail: (String) -> Unit
 ) {
     LaunchedEffect(Unit) {
         viewModel.store.onIntent(ScheduleIntent.EnterScheduleScreen)
@@ -66,6 +67,7 @@ internal fun ScheduleRoute(
         when (effect) {
             is ScheduleSideEffect.HandleException -> handleException(effect.exception)
             ScheduleSideEffect.NavigateToLogin -> navigateToLogin()
+            is ScheduleSideEffect.NavigateToSessionDetail -> navigateToSessionDetail(effect.id)
         }
     }
 
@@ -128,7 +130,8 @@ internal fun ScheduleScreen(
 
                     ScheduleTab.SESSION -> ScheduleSessionScreen(
                         upcomingSessions = scheduleState.upcomingSessions,
-                        sessions = scheduleState.sessions
+                        sessions = scheduleState.sessions,
+                        onIntent = onIntent
                     )
                 }
             }
@@ -192,7 +195,9 @@ private fun ScheduleAllScreen(
                     isToday = grouped.isToday,
                     showMonth = true,
                     schedules = grouped.schedules,
-                ) { }
+                ) { id ->
+                    onIntent(ScheduleIntent.ClickSessionItem(id))
+                }
 
                 if (index < schedules.dates.lastIndex) {
                     Spacer(modifier = Modifier.height(16.dp))
@@ -208,6 +213,7 @@ private fun ScheduleAllScreen(
 private fun ScheduleSessionScreen(
     upcomingSessions: List<ScheduleInfo>,
     sessions: ScheduleList,
+    onIntent: (ScheduleIntent) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxWidth()
@@ -281,7 +287,9 @@ private fun ScheduleSessionScreen(
                 isToday = grouped.isToday,
                 showMonth = true,
                 schedules = grouped.schedules,
-            ) { }
+            ) { id ->
+                onIntent(ScheduleIntent.ClickSessionItem(id))
+            }
 
             if (index < sessions.dates.lastIndex) {
                 Spacer(modifier = Modifier.height(16.dp))

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
@@ -187,7 +187,7 @@ private fun ScheduleAllScreen(
 
             }
         } else {
-            itemsIndexed(schedules.dates, key = { _, it -> it.date }) { index, grouped ->
+            itemsIndexed(schedules.dates, key = { index, it -> "${it.date}_$index" }) { index, grouped ->
                 DateGroupedScheduleItem(
                     variant = ScheduleGroupVariant.LEFT_ALIGNED,
                     date = grouped.date,
@@ -279,7 +279,7 @@ private fun ScheduleSessionScreen(
             )
         }
 
-        itemsIndexed(sessions.dates, key = { _, it -> it.date }) { index, grouped ->
+        itemsIndexed(sessions.dates, key = { index, it -> "${it.date}_$index" }) { index, grouped ->
             DateGroupedScheduleItem(
                 variant = ScheduleGroupVariant.TOP_ALIGNED,
                 date = grouped.date,

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -41,6 +41,7 @@ import com.yapp.core.ui.component.LocalBottomBarHeight
 import com.yapp.core.ui.component.YappBackground
 import com.yapp.core.ui.extension.collectWithLifecycle
 import com.yapp.feature.schedule.component.DateGroupedScheduleItem
+import com.yapp.feature.schedule.component.ScheduleGroupVariant
 import com.yapp.feature.schedule.component.ScheduleTabRow
 import com.yapp.feature.schedule.component.UpcomingSessionSection
 import com.yapp.model.AttendanceStatus
@@ -157,7 +158,7 @@ private fun ScheduleAllScreen(
                 onPreviousMonthClick = { onIntent(ScheduleIntent.ClickPreviousMonth) },
                 onNextMonthClick = { onIntent(ScheduleIntent.ClickNextMonth) }
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(16.dp))
         }
         if (schedules.isEmpty) {
             item {
@@ -183,18 +184,22 @@ private fun ScheduleAllScreen(
 
             }
         } else {
-            items(
-                items = schedules.dates,
-                key = { it.date },
-            ) {
+            itemsIndexed(schedules.dates, key = { _, it -> it.date }) { index, grouped ->
                 DateGroupedScheduleItem(
-                    date = it.date,
-                    dayOfWeek = it.dayOfTheWeek,
-                    isToday = it.isToday,
-                    schedules = it.schedules,
+                    variant = ScheduleGroupVariant.TOP_ALIGNED,
+                    date = grouped.date,
+                    dayOfWeek = grouped.dayOfTheWeek,
+                    isToday = grouped.isToday,
+                    showMonth = true,
+                    schedules = grouped.schedules,
                 ) { }
+
+                if (index < schedules.dates.lastIndex) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
             }
 
+            item { Spacer(modifier = Modifier.height(8.dp)) }
         }
     }
 }
@@ -268,18 +273,22 @@ private fun ScheduleSessionScreen(
             )
         }
 
-        items(
-            items = sessions.dates,
-            key = { it.date },
-        ) {
+        itemsIndexed(sessions.dates, key = { _, it -> it.date }) { index, grouped ->
             DateGroupedScheduleItem(
-                date = it.date,
-                dayOfWeek = it.dayOfTheWeek,
-                isToday = it.isToday,
+                variant = ScheduleGroupVariant.TOP_ALIGNED,
+                date = grouped.date,
+                dayOfWeek = grouped.dayOfTheWeek,
+                isToday = grouped.isToday,
                 showMonth = true,
-                schedules = it.schedules,
+                schedules = grouped.schedules,
             ) { }
+
+            if (index < sessions.dates.lastIndex) {
+                Spacer(modifier = Modifier.height(16.dp))
+            }
         }
+
+        item { Spacer(modifier = Modifier.height(8.dp)) }
     }
 }
 

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
@@ -204,7 +204,7 @@ private fun ScheduleAllScreen(
                 }
             }
 
-            item { Spacer(modifier = Modifier.height(8.dp)) }
+            item { Spacer(modifier = Modifier.height(20.dp)) }
         }
     }
 }
@@ -296,7 +296,7 @@ private fun ScheduleSessionScreen(
             }
         }
 
-        item { Spacer(modifier = Modifier.height(8.dp)) }
+        item { Spacer(modifier = Modifier.height(20.dp)) }
     }
 }
 

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleViewModel.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleViewModel.kt
@@ -67,6 +67,10 @@ class ScheduleViewModel @Inject constructor(
                 reduce { copy(selectedYear = newYear, selectedMonth = newMonth) }
                 loadScheduleInfo(newYear, newMonth, reduce, postSideEffect)
             }
+
+            is ScheduleIntent.ClickSessionItem -> {
+                postSideEffect(ScheduleSideEffect.NavigateToSessionDetail(intent.id))
+            }
         }
     }
 

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/AssignmentItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/AssignmentItem.kt
@@ -10,11 +10,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yapp.core.designsystem.extension.yappClickable
 import com.yapp.core.designsystem.theme.YappTheme
 import com.yapp.core.ui.extension.dashedBorder
+
+private val ASSIGNMENT_ITEM_CORNER_RADIUS = 12.dp
 
 @Composable
 internal fun AssignmentItem(
@@ -33,9 +36,10 @@ internal fun AssignmentItem(
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .clip(RoundedCornerShape(ASSIGNMENT_ITEM_CORNER_RADIUS))
             .background(
                 color = backgroundColor,
-                shape = RoundedCornerShape(12.dp),
+                shape = RoundedCornerShape(ASSIGNMENT_ITEM_CORNER_RADIUS),
             )
             .then(
                 if (dateState == SessionDateState.FUTURE) {
@@ -44,17 +48,17 @@ internal fun AssignmentItem(
                         strokeWidth = 1.dp,
                         dashLength = 2.dp,
                         gapLength = 2.dp,
-                        cornerRadius = 12.dp
+                        cornerRadius = ASSIGNMENT_ITEM_CORNER_RADIUS
                     )
                 } else {
                     Modifier
                 }
             )
+            .yappClickable { onClick(id) }
             .padding(
                 horizontal = 12.dp,
                 vertical = 10.dp,
             )
-            .yappClickable { onClick(id) }
     ) {
         Spacer(modifier = Modifier.height(2.dp))
 

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/AssignmentItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/AssignmentItem.kt
@@ -1,9 +1,12 @@
 package com.yapp.feature.schedule.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -11,17 +14,46 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yapp.core.designsystem.extension.yappClickable
 import com.yapp.core.designsystem.theme.YappTheme
+import com.yapp.core.ui.extension.dashedBorder
 
 @Composable
 internal fun AssignmentItem(
     id: String,
     title: String,
     content: String,
+    dateState: SessionDateState,
     onClick: (String) -> Unit,
 ) {
+    val backgroundColor = when (dateState) {
+        SessionDateState.TODAY -> YappTheme.colorScheme.orange99
+        SessionDateState.PAST -> YappTheme.colorScheme.backgroundElevatedAlternative
+        SessionDateState.FUTURE -> YappTheme.colorScheme.staticWhite
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .background(
+                color = backgroundColor,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .then(
+                if (dateState == SessionDateState.FUTURE) {
+                    Modifier.dashedBorder(
+                        color = YappTheme.colorScheme.labelDisable,
+                        strokeWidth = 1.dp,
+                        dashLength = 2.dp,
+                        gapLength = 2.dp,
+                        cornerRadius = 12.dp
+                    )
+                } else {
+                    Modifier
+                }
+            )
+            .padding(
+                horizontal = 12.dp,
+                vertical = 10.dp,
+            )
             .yappClickable { onClick(id) }
     ) {
         Spacer(modifier = Modifier.height(2.dp))
@@ -52,6 +84,7 @@ private fun AssignmentItemPreview() {
             id = "1",
             title = "과제 제목",
             content = "과제 내용",
+            dateState = SessionDateState.TODAY,
             onClick = {}
         )
     }

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/DateGroupedScheduleItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/DateGroupedScheduleItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
@@ -28,8 +29,13 @@ import com.yapp.model.ScheduleType
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+enum class ScheduleGroupVariant {
+    LEFT_ALIGNED, TOP_ALIGNED
+}
+
 @Composable
 internal fun DateGroupedScheduleItem(
+    variant: ScheduleGroupVariant,
     date: String,
     dayOfWeek: String,
     isToday: Boolean,
@@ -37,9 +43,6 @@ internal fun DateGroupedScheduleItem(
     showMonth: Boolean = false,
     onClick: (String) -> Unit,
 ) {
-    val context = LocalContext.current
-    val configuration = LocalConfiguration.current
-
     val today = remember { LocalDate.now() }
     val parsedDate = remember(date) {
         runCatching { LocalDate.parse(date, DateTimeFormatter.ISO_DATE) }.getOrNull()
@@ -56,90 +59,138 @@ internal fun DateGroupedScheduleItem(
 
     val faded = remember(date) { isPastDate(date) }
 
+    when (variant) {
+        ScheduleGroupVariant.LEFT_ALIGNED -> {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .graphicsLayer { if (faded) alpha = 0.5f }
+                    .padding(horizontal = 20.dp)
+            ) {
+                DateHeader(
+                    date = date,
+                    dayOfWeek = dayOfWeek,
+                    isToday = isToday,
+                    showMonth = showMonth
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                ScheduleList(
+                    schedules = schedules,
+                    dateState = dateState,
+                    onClick = onClick
+                )
+            }
+        }
+
+        ScheduleGroupVariant.TOP_ALIGNED -> {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .graphicsLayer { if (faded) alpha = 0.5f }
+                    .padding(horizontal = 20.dp),
+            ) {
+                DateHeader(
+                    date = date,
+                    dayOfWeek = dayOfWeek,
+                    isToday = isToday,
+                    showMonth = showMonth
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                ScheduleList(
+                    modifier = Modifier.padding(horizontal = 8.dp),
+                    schedules = schedules,
+                    dateState = dateState,
+                    onClick = onClick
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DateHeader(
+    date: String,
+    dayOfWeek: String,
+    isToday: Boolean,
+    showMonth: Boolean,
+) {
+    val context = LocalContext.current
+
+    val dateColor = if (isToday) YappTheme.colorScheme.primaryNormal else YappTheme.colorScheme.labelNeutral
+    val dateWidth = if (showMonth) 72.dp else 60.dp
+
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .graphicsLayer { if (faded) alpha = 0.5f }
-            .padding(
-                horizontal = 20.dp,
-                vertical = 16.dp
-            )
+        modifier = Modifier.width(dateWidth),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        val dateColor = if (isToday) {
-            YappTheme.colorScheme.primaryNormal
-        } else {
-            YappTheme.colorScheme.labelNeutral
-        }
-        val dateWidth = if (showMonth) 72.dp else 60.dp
+        Text(
+            text = formatToDay(context, date, showMonth),
+            style = YappTheme.typography.body1NormalBold,
+            color = dateColor
+        )
+        Text(
+            text = "(${dayOfWeek})",
+            style = YappTheme.typography.caption1Medium,
+            color = dateColor
+        )
+    }
+}
 
-        Row(
-            modifier = Modifier.width(dateWidth),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = formatToDay(context, date, showMonth),
-                style = YappTheme.typography.body1NormalBold,
-                color = dateColor
-            )
+@Composable
+private fun ScheduleList(
+    modifier: Modifier = Modifier,
+    schedules: List<ScheduleInfo>,
+    dateState: SessionDateState,
+    onClick: (String) -> Unit
+) {
+    val context = LocalContext.current
+    val configuration = LocalConfiguration.current
 
-            Text(
-                text = "(${dayOfWeek})",
-                style = YappTheme.typography.caption1Medium,
-                color = dateColor
-            )
-        }
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        schedules.forEach { schedule ->
+            val duration = remember(
+                configuration,
+                schedule.date,
+                schedule.startDayOfWeek,
+                schedule.time,
+                schedule.endDate,
+                schedule.endDayOfWeek,
+                schedule.endTime
+            ) {
+                formatScheduleTimeRange(
+                    context = context,
+                    date = schedule.date,
+                    startDayOfWeek = schedule.startDayOfWeek,
+                    time = schedule.time,
+                    endDate = schedule.endDate,
+                    endDayOfWeek = schedule.endDayOfWeek,
+                    endTime = schedule.endTime,
+                )
+            }
 
-        Spacer(modifier = Modifier.width(8.dp))
+            when (schedule.scheduleType) {
+                ScheduleType.SESSION -> SessionItem(
+                    id = schedule.id,
+                    title = schedule.name,
+                    attendanceStatus = schedule.attendanceStatus,
+                    scheduleProgressPhase = schedule.scheduleProgressPhase,
+                    location = schedule.place,
+                    duration = duration,
+                    dateState = dateState,
+                    onClick = onClick
+                )
 
-        Column(
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            schedules.forEach { schedule ->
-                when (schedule.scheduleType) {
-                    ScheduleType.SESSION -> {
-                        val duration = remember(
-                            configuration,
-                            schedule.date,
-                            schedule.startDayOfWeek,
-                            schedule.time,
-                            schedule.endDate,
-                            schedule.endDayOfWeek,
-                            schedule.endTime
-                        ) {
-                            formatScheduleTimeRange(
-                                context = context,
-                                date = schedule.date,
-                                startDayOfWeek = schedule.startDayOfWeek,
-                                time = schedule.time,
-                                endDate = schedule.endDate,
-                                endDayOfWeek = schedule.endDayOfWeek,
-                                endTime = schedule.endTime,
-                            )
-                        }
-
-                        SessionItem(
-                            id = schedule.id,
-                            title = schedule.name,
-                            attendanceStatus = schedule.attendanceStatus,
-                            scheduleProgressPhase = schedule.scheduleProgressPhase,
-                            location = schedule.place,
-                            duration = duration,
-                            dateState = dateState,
-                            onClick = onClick,
-                        )
-                    }
-
-                    ScheduleType.TASK, ScheduleType.ETC -> {
-                        AssignmentItem(
-                            id = schedule.id,
-                            title = schedule.name,
-                            content = "",
-                            dateState = dateState,
-                            onClick = onClick,
-                        )
-                    }
-                }
+                ScheduleType.TASK, ScheduleType.ETC -> AssignmentItem(
+                    id = schedule.id,
+                    title = schedule.name,
+                    content = "",
+                    dateState = dateState,
+                    onClick = onClick
+                )
             }
         }
     }
@@ -151,9 +202,94 @@ internal fun DateGroupedScheduleItem(
 @Composable
 private fun DateGroupedScheduleItemPreview() {
     YappTheme {
-        Column {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
             DateGroupedScheduleItem(
                 date = "2025-11-02",
+                variant = ScheduleGroupVariant.LEFT_ALIGNED,
+                dayOfWeek = "일",
+                isToday = true,
+                schedules = listOf(
+                    ScheduleInfo(
+                        id = "1",
+                        name = "세션 제목",
+                        scheduleType = ScheduleType.SESSION,
+                        attendanceStatus = null,
+                        place = "공덕 창업허브",
+                        time = "14:00",
+                        endTime = "18:00",
+                        startDayOfWeek = "일",
+                        endDayOfWeek = "일",
+                        sessionType = null,
+                        scheduleProgressPhase = ScheduleProgressPhase.ONGOING,
+                        date = "2023-10-01",
+                        endDate = "2023-10-01"
+                    ),
+                    ScheduleInfo(
+                        id = "2",
+                        name = "과제 제목",
+                        scheduleType = ScheduleType.TASK,
+                        attendanceStatus = AttendanceStatus.ATTENDED,
+                        place = null,
+                        time = "14:00",
+                        endTime = "18:00",
+                        startDayOfWeek = "일",
+                        endDayOfWeek = "일",
+                        sessionType = null,
+                        scheduleProgressPhase = ScheduleProgressPhase.TODAY,
+                        date = "2023-10-01",
+                        endDate = "2023-10-01"
+                    ),
+                    ScheduleInfo(
+                        id = "3",
+                        name = "세션 제목",
+                        scheduleType = ScheduleType.SESSION,
+                        attendanceStatus = AttendanceStatus.EARLY_LEAVE,
+                        place = "공덕 창업허브",
+                        time = "14:00",
+                        endTime = "18:00",
+                        startDayOfWeek = "일",
+                        endDayOfWeek = "일",
+                        sessionType = null,
+                        scheduleProgressPhase = ScheduleProgressPhase.ONGOING,
+                        date = "2023-10-01",
+                        endDate = "2023-11-01"
+                    ),
+                ),
+                showMonth = false,
+                onClick = {}
+            )
+
+            DateGroupedScheduleItem(
+                date = "2025-12-02",
+                variant = ScheduleGroupVariant.LEFT_ALIGNED,
+                dayOfWeek = "일",
+                isToday = false,
+                schedules = listOf(
+                    ScheduleInfo(
+                        id = "1",
+                        name = "세션 제목",
+                        scheduleType = ScheduleType.SESSION,
+                        attendanceStatus = AttendanceStatus.ATTENDED,
+                        place = "공덕 창업허브",
+                        time = "14:00",
+                        endTime = "18:00",
+                        startDayOfWeek = "일",
+                        endDayOfWeek = "일",
+                        sessionType = null,
+                        scheduleProgressPhase = ScheduleProgressPhase.ONGOING,
+                        date = "2023-10-01",
+                        endDate = "2023-10-01"
+                    ),
+                ),
+                showMonth = false,
+                onClick = {}
+            )
+
+            DateGroupedScheduleItem(
+                date = "2025-11-02",
+                variant = ScheduleGroupVariant.TOP_ALIGNED,
                 dayOfWeek = "일",
                 isToday = true,
                 schedules = listOf(
@@ -209,6 +345,7 @@ private fun DateGroupedScheduleItemPreview() {
 
             DateGroupedScheduleItem(
                 date = "2025-05-24",
+                variant = ScheduleGroupVariant.TOP_ALIGNED,
                 dayOfWeek = "일",
                 isToday = false,
                 schedules = listOf(

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/DateGroupedScheduleItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/DateGroupedScheduleItem.kt
@@ -25,6 +25,8 @@ import com.yapp.model.AttendanceStatus
 import com.yapp.model.ScheduleInfo
 import com.yapp.model.ScheduleProgressPhase
 import com.yapp.model.ScheduleType
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Composable
 internal fun DateGroupedScheduleItem(
@@ -37,6 +39,20 @@ internal fun DateGroupedScheduleItem(
 ) {
     val context = LocalContext.current
     val configuration = LocalConfiguration.current
+
+    val today = remember { LocalDate.now() }
+    val parsedDate = remember(date) {
+        runCatching { LocalDate.parse(date, DateTimeFormatter.ISO_DATE) }.getOrNull()
+    }
+
+    val dateState = remember(parsedDate, today) {
+        when {
+            parsedDate == null -> SessionDateState.FUTURE
+            parsedDate.isEqual(today) -> SessionDateState.TODAY
+            parsedDate.isBefore(today) -> SessionDateState.PAST
+            else -> SessionDateState.FUTURE
+        }
+    }
 
     val faded = remember(date) { isPastDate(date) }
 
@@ -74,7 +90,7 @@ internal fun DateGroupedScheduleItem(
             )
         }
 
-        Spacer(modifier = Modifier.width(20.dp))
+        Spacer(modifier = Modifier.width(8.dp))
 
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -109,6 +125,7 @@ internal fun DateGroupedScheduleItem(
                             scheduleProgressPhase = schedule.scheduleProgressPhase,
                             location = schedule.place,
                             duration = duration,
+                            dateState = dateState,
                             onClick = onClick,
                         )
                     }
@@ -118,6 +135,7 @@ internal fun DateGroupedScheduleItem(
                             id = schedule.id,
                             title = schedule.name,
                             content = "",
+                            dateState = dateState,
                             onClick = onClick,
                         )
                     }
@@ -135,7 +153,7 @@ private fun DateGroupedScheduleItemPreview() {
     YappTheme {
         Column {
             DateGroupedScheduleItem(
-                date = "2025-05-08",
+                date = "2025-11-02",
                 dayOfWeek = "일",
                 isToday = true,
                 schedules = listOf(
@@ -151,8 +169,8 @@ private fun DateGroupedScheduleItemPreview() {
                         endDayOfWeek = "일",
                         sessionType = null,
                         scheduleProgressPhase = ScheduleProgressPhase.ONGOING,
-                        date = "2023.10.01",
-                        endDate = "2023.10.01"
+                        date = "2023-10-01",
+                        endDate = "2023-10-01"
                     ),
                     ScheduleInfo(
                         id = "2",
@@ -166,8 +184,8 @@ private fun DateGroupedScheduleItemPreview() {
                         endDayOfWeek = "일",
                         sessionType = null,
                         scheduleProgressPhase = ScheduleProgressPhase.TODAY,
-                        date = "2023.10.01",
-                        endDate = "2023.10.01"
+                        date = "2023-10-01",
+                        endDate = "2023-10-01"
                     ),
                     ScheduleInfo(
                         id = "3",
@@ -181,8 +199,8 @@ private fun DateGroupedScheduleItemPreview() {
                         endDayOfWeek = "일",
                         sessionType = null,
                         scheduleProgressPhase = ScheduleProgressPhase.ONGOING,
-                        date = "2023.10.01",
-                        endDate = "2023.10.01"
+                        date = "2023-10-01",
+                        endDate = "2023-11-01"
                     ),
                 ),
                 showMonth = true,
@@ -206,8 +224,8 @@ private fun DateGroupedScheduleItemPreview() {
                         endDayOfWeek = "일",
                         sessionType = null,
                         scheduleProgressPhase = ScheduleProgressPhase.ONGOING,
-                        date = "2023.10.01",
-                        endDate = "2023.10.01"
+                        date = "2023-10-01",
+                        endDate = "2023-10-01"
                     ),
                 ),
                 showMonth = true,

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/DateGroupedScheduleItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/DateGroupedScheduleItem.kt
@@ -189,7 +189,7 @@ private fun ScheduleList(
                     title = schedule.name,
                     content = "",
                     dateState = dateState,
-                    onClick = onClick
+                    onClick = {  }
                 )
             }
         }

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yapp.core.designsystem.R
@@ -46,6 +47,7 @@ internal fun SessionItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
             .background(
                 color = backgroundColor,
                 shape = RoundedCornerShape(12.dp),
@@ -63,11 +65,11 @@ internal fun SessionItem(
                     Modifier
                 }
             )
+            .yappClickable { onClick(id) }
             .padding(
                 horizontal = 12.dp,
                 vertical = 10.dp,
             )
-            .yappClickable { onClick(id) }
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Spacer(modifier = Modifier.height(2.dp))

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
@@ -1,11 +1,14 @@
 package com.yapp.feature.schedule.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,8 +18,13 @@ import com.yapp.core.designsystem.R
 import com.yapp.core.designsystem.extension.yappClickable
 import com.yapp.core.designsystem.theme.YappTheme
 import com.yapp.core.ui.component.ScheduleStatusChip
+import com.yapp.core.ui.extension.dashedBorder
 import com.yapp.model.AttendanceStatus
 import com.yapp.model.ScheduleProgressPhase
+
+enum class SessionDateState {
+    PAST, TODAY, FUTURE
+}
 
 @Composable
 internal fun SessionItem(
@@ -26,11 +34,39 @@ internal fun SessionItem(
     scheduleProgressPhase: ScheduleProgressPhase,
     location: String?,
     duration: String?,
+    dateState: SessionDateState,
     onClick: (String) -> Unit,
 ) {
+    val backgroundColor = when (dateState) {
+        SessionDateState.TODAY -> YappTheme.colorScheme.orange99
+        SessionDateState.PAST -> YappTheme.colorScheme.backgroundElevatedAlternative
+        SessionDateState.FUTURE -> YappTheme.colorScheme.staticWhite
+    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .background(
+                color = backgroundColor,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .then(
+                if (dateState == SessionDateState.FUTURE) {
+                    Modifier.dashedBorder(
+                        color = YappTheme.colorScheme.labelDisable,
+                        strokeWidth = 1.dp,
+                        dashLength = 2.dp,
+                        gapLength = 2.dp,
+                        cornerRadius = 12.dp
+                    )
+                } else {
+                    Modifier
+                }
+            )
+            .padding(
+                horizontal = 12.dp,
+                vertical = 10.dp,
+            )
             .yappClickable { onClick(id) }
     ) {
         Column(modifier = Modifier.weight(1f)) {
@@ -44,20 +80,20 @@ internal fun SessionItem(
 
             Spacer(modifier = Modifier.height(6.dp))
 
-            duration?.let {
-                IconWithText(
-                    iconResId = R.drawable.icon_time,
-                    text = duration,
-                    contentDescription = null,
-                )
-            }
-
             if (!location.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(4.dp))
 
                 IconWithText(
                     iconResId = R.drawable.icon_location,
                     text = location,
+                    contentDescription = null,
+                )
+            }
+
+            duration?.let {
+                IconWithText(
+                    iconResId = R.drawable.icon_time,
+                    text = duration,
                     contentDescription = null,
                 )
             }
@@ -87,6 +123,7 @@ private fun PreviewSessionItem() {
                 scheduleProgressPhase = ScheduleProgressPhase.DONE,
                 location = "공덕 창업허브",
                 duration = "오후 2시 - 오후 6시",
+                dateState = SessionDateState.TODAY,
                 onClick = {}
             )
 
@@ -94,9 +131,10 @@ private fun PreviewSessionItem() {
                 id = "2",
                 title = "세션 제목",
                 attendanceStatus = AttendanceStatus.ATTENDED,
-                scheduleProgressPhase = ScheduleProgressPhase.DONE,
+                scheduleProgressPhase = ScheduleProgressPhase.ONGOING,
                 location = "공덕 창업허브",
                 duration = "오후 2시 - 오후 6시",
+                dateState = SessionDateState.PAST,
                 onClick = {}
             )
 
@@ -104,9 +142,10 @@ private fun PreviewSessionItem() {
                 id = "3",
                 title = "세션 제목",
                 attendanceStatus = AttendanceStatus.EARLY_LEAVE,
-                scheduleProgressPhase = ScheduleProgressPhase.DONE,
+                scheduleProgressPhase = ScheduleProgressPhase.PENDING,
                 location = "공덕 창업허브",
                 duration = "오후 2시 - 오후 6시",
+                dateState = SessionDateState.FUTURE,
                 onClick = {}
             )
         }

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
@@ -27,6 +27,8 @@ enum class SessionDateState {
     PAST, TODAY, FUTURE
 }
 
+private val SESSION_ITEM_CORNER_RADIUS = 12.dp
+
 @Composable
 internal fun SessionItem(
     id: String,
@@ -47,10 +49,10 @@ internal fun SessionItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(SESSION_ITEM_CORNER_RADIUS))
             .background(
                 color = backgroundColor,
-                shape = RoundedCornerShape(12.dp),
+                shape = RoundedCornerShape(SESSION_ITEM_CORNER_RADIUS),
             )
             .then(
                 if (dateState == SessionDateState.FUTURE) {
@@ -59,7 +61,7 @@ internal fun SessionItem(
                         strokeWidth = 1.dp,
                         dashLength = 2.dp,
                         gapLength = 2.dp,
-                        cornerRadius = 12.dp
+                        cornerRadius = SESSION_ITEM_CORNER_RADIUS
                     )
                 } else {
                     Modifier

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
@@ -81,8 +81,6 @@ internal fun SessionItem(
             Spacer(modifier = Modifier.height(6.dp))
 
             if (!location.isNullOrBlank()) {
-                Spacer(modifier = Modifier.height(4.dp))
-
                 IconWithText(
                     iconResId = R.drawable.icon_location,
                     text = location,
@@ -91,6 +89,8 @@ internal fun SessionItem(
             }
 
             duration?.let {
+                Spacer(modifier = Modifier.height(4.dp))
+
                 IconWithText(
                     iconResId = R.drawable.icon_time,
                     text = duration,

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/component/SessionItem.kt
@@ -3,7 +3,6 @@ package com.yapp.feature.schedule.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -46,7 +45,7 @@ internal fun SessionItem(
         SessionDateState.FUTURE -> YappTheme.colorScheme.staticWhite
     }
 
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(SESSION_ITEM_CORNER_RADIUS))
@@ -68,45 +67,40 @@ internal fun SessionItem(
                 }
             )
             .yappClickable { onClick(id) }
-            .padding(
-                horizontal = 12.dp,
-                vertical = 10.dp,
-            )
+            .padding(12.dp)
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Spacer(modifier = Modifier.height(2.dp))
-
-            Text(
-                text = title,
-                style = YappTheme.typography.label1NormalBold,
-                color = YappTheme.colorScheme.labelNormal
-            )
-
-            Spacer(modifier = Modifier.height(6.dp))
-
-            if (!location.isNullOrBlank()) {
-                IconWithText(
-                    iconResId = R.drawable.icon_location,
-                    text = location,
-                    contentDescription = null,
-                )
-            }
-
-            duration?.let {
-                Spacer(modifier = Modifier.height(4.dp))
-
-                IconWithText(
-                    iconResId = R.drawable.icon_time,
-                    text = duration,
-                    contentDescription = null,
-                )
-            }
-        }
-
         if (attendanceStatus != null || scheduleProgressPhase == ScheduleProgressPhase.PENDING) {
             ScheduleStatusChip(
                 attendanceStatus = attendanceStatus,
                 scheduleProgressPhase = scheduleProgressPhase
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+
+        Text(
+            text = title,
+            style = YappTheme.typography.label1NormalBold,
+            color = YappTheme.colorScheme.labelNormal
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        if (!location.isNullOrBlank()) {
+            IconWithText(
+                iconResId = R.drawable.icon_location,
+                text = location,
+                contentDescription = null,
+            )
+        }
+
+        duration?.let {
+            Spacer(modifier = Modifier.height(4.dp))
+
+            IconWithText(
+                iconResId = R.drawable.icon_time,
+                text = duration,
+                contentDescription = null,
             )
         }
     }

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/navigation/ScheduleNavigation.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/navigation/ScheduleNavigation.kt
@@ -17,11 +17,13 @@ fun NavController.navigateToSchedule(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.scheduleNavGraph(
     handleException: (Throwable) -> Unit,
     navigateToLogin: () -> Unit,
+    navigateToSessionDetail: (String) -> Unit
 ) {
     composable<ScheduleRoute> {
         ScheduleRoute(
             handleException = handleException,
             navigateToLogin = navigateToLogin,
+            navigateToSessionDetail = navigateToSessionDetail
         )
     }
 }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #229 

## 🌱 Key changes
<!--변경사항 적기-->

- 일정 탭 UI 변경에 따른 세션/과제 아이템 UI 변경
- 전체 탭, 세션 탭 클릭 시에 따라 DateGroupedScheduleItem 정렬 분기 처리
- 세션 아이템 클릭 시 상세 화면 이동

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

`/v1/schedules` API랑 `/v1/active-generation/sessions` API랑 정합성이 맞지 않는 것 같은데 이부분은 찬기님께 말씀드릴게요

## 📸 스크린샷
| 전체 탭 | 일정 탭 |
|:--:|:--:|
| <img width="339" height="754" alt="image" src="https://github.com/user-attachments/assets/b9a9910f-12bd-4296-9a56-22b5381c8fb6" /> | <img width="339" height="754" alt="image" src="https://github.com/user-attachments/assets/c1f95326-a817-4d2d-b748-a3aca6feeab2" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정 목록에서 세션을 클릭하여 상세 정보를 볼 수 있습니다.

* **UI/디자인 개선**
  * 세션 항목이 날짜 상태(과거/오늘/미래)에 따라 다른 색상과 스타일로 표시됩니다.
  * 일정 화면의 레이아웃과 간격이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->