### PR TITLE
[Feature] 일정 전체, 세션 탭 전환 간 스크롤 상태 보존

### DIFF
--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
@@ -1,5 +1,6 @@
 package com.yapp.feature.schedule
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -14,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -23,7 +26,9 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -51,6 +56,8 @@ import com.yapp.model.ScheduleList
 import com.yapp.model.ScheduleProgressPhase
 import com.yapp.model.ScheduleType
 import com.yapp.model.SessionType
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
 internal fun ScheduleRoute(
@@ -78,7 +85,7 @@ internal fun ScheduleRoute(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 internal fun ScheduleScreen(
     scheduleState: ScheduleState,
@@ -86,6 +93,29 @@ internal fun ScheduleScreen(
 ) {
     val pullToRefreshState = rememberPullToRefreshState()
     val saveableStateHolder = rememberSaveableStateHolder()
+    val pagerState = rememberPagerState(
+        initialPage = scheduleState.selectedTab.ordinal,
+        pageCount = { ScheduleTab.entries.size }
+    )
+    val currentSelectedTab by rememberUpdatedState(scheduleState.selectedTab)
+
+    LaunchedEffect(scheduleState.selectedTab) {
+        val targetPage = scheduleState.selectedTab.ordinal
+        if (pagerState.currentPage != targetPage) {
+            pagerState.animateScrollToPage(targetPage)
+        }
+    }
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }
+            .distinctUntilChanged()
+            .collectLatest { page ->
+                val tab = ScheduleTab.entries[page]
+                if (tab != currentSelectedTab) {
+                    onIntent(ScheduleIntent.SelectTab(tab))
+                }
+            }
+    }
 
     YappBackground(
         color = YappTheme.colorScheme.staticWhite,
@@ -118,8 +148,12 @@ internal fun ScheduleScreen(
                     }
                 )
 
-                saveableStateHolder.SaveableStateProvider(key = scheduleState.selectedTab) {
-                    when (scheduleState.selectedTab) {
+                HorizontalPager(
+                    modifier = Modifier.fillMaxSize(),
+                    state = pagerState
+                ) { page ->
+                    val tab = ScheduleTab.entries[page]
+                    when (tab) {
                         ScheduleTab.ALL -> {
                             ScheduleAllScreen(
                                 selectedYear = scheduleState.selectedYear,

--- a/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
+++ b/feature/schedule/src/main/java/com/yapp/feature/schedule/ScheduleScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -84,6 +85,7 @@ internal fun ScheduleScreen(
     onIntent: (ScheduleIntent) -> Unit = {},
 ) {
     val pullToRefreshState = rememberPullToRefreshState()
+    val saveableStateHolder = rememberSaveableStateHolder()
 
     YappBackground(
         color = YappTheme.colorScheme.staticWhite,
@@ -116,23 +118,25 @@ internal fun ScheduleScreen(
                     }
                 )
 
-                when (scheduleState.selectedTab) {
-                    ScheduleTab.ALL -> {
-                        ScheduleAllScreen(
-                            selectedYear = scheduleState.selectedYear,
-                            selectedMonth = scheduleState.selectedMonth,
-                            schedules = scheduleState.schedules[
-                                Pair(scheduleState.selectedYear, scheduleState.selectedMonth)
-                            ] ?: ScheduleList(emptyList()),
+                saveableStateHolder.SaveableStateProvider(key = scheduleState.selectedTab) {
+                    when (scheduleState.selectedTab) {
+                        ScheduleTab.ALL -> {
+                            ScheduleAllScreen(
+                                selectedYear = scheduleState.selectedYear,
+                                selectedMonth = scheduleState.selectedMonth,
+                                schedules = scheduleState.schedules[
+                                    Pair(scheduleState.selectedYear, scheduleState.selectedMonth)
+                                ] ?: ScheduleList(emptyList()),
+                                onIntent = onIntent
+                            )
+                        }
+
+                        ScheduleTab.SESSION -> ScheduleSessionScreen(
+                            upcomingSessions = scheduleState.upcomingSessions,
+                            sessions = scheduleState.sessions,
                             onIntent = onIntent
                         )
                     }
-
-                    ScheduleTab.SESSION -> ScheduleSessionScreen(
-                        upcomingSessions = scheduleState.upcomingSessions,
-                        sessions = scheduleState.sessions,
-                        onIntent = onIntent
-                    )
                 }
             }
         }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #235 

## 🌱 Key changes
<!--변경사항 적기-->
전체, 세션 탭 전환 간 클릭할 때마다 API 새로고침을 하지 않는 상황에서
스크롤 상태도 초기화되는 것이 UX적으로 어색한 거 같아 SaveableStateHolder로 스크롤 상태 보존했어요

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
커밋 하나 짜리이긴 한데... 이슈를 파놔서 이슈에 작업했습니다.

## 📸 스크린샷

https://github.com/user-attachments/assets/e62b9529-a6ba-4eb7-91a4-b1c792b63608
