### PR TITLE
[Chore] Firebase App Distribution을 통한 앱 배포 workflow dispatch 설정

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -1,0 +1,60 @@
+name: Firebase App Distribution
+
+on:
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: 'Fastlane lane'
+        required: true
+        default: 'distribute_qa'
+        type: choice
+        options:
+          - distribute_qa
+          - distribute_qa_test
+      branch:
+        description: '배포할 브랜치'
+        required: true
+        default: 'develop'
+        type: string
+
+permissions: write-all
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - uses: ./.github/actions/build-configuration
+        with:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          BASE_URL_DEBUG: ${{ secrets.BASE_URL_DEBUG }}
+          BASE_URL_RELEASE: ${{ secrets.BASE_URL_RELEASE }}
+          BASE_URL_QA: ${{ secrets.BASE_URL_QA }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Decode Firebase credentials
+        run: echo '${{ secrets.FIREBASE_CREDENTIAL_JSON }}' > fastlane/credentials.json
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Fastlane
+        env:
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_CREDENTIAL_PATH: ./credentials.json
+          FIREBASE_GROUP: ${{ secrets.FIREBASE_GROUP }}
+        run: bundle exec fastlane android ${{ inputs.lane }}

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -17,7 +17,8 @@ on:
         default: 'develop'
         type: string
 
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
   distribute:

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -59,3 +59,7 @@ jobs:
           FIREBASE_CREDENTIAL_PATH: ./credentials.json
           FIREBASE_GROUP: ${{ secrets.FIREBASE_GROUP }}
         run: bundle exec fastlane android ${{ inputs.lane }}
+
+      - name: Clean up Firebase credentials
+        if: always()
+        run: rm -f fastlane/credentials.json

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: fb-distribute-${{ inputs.branch }}-${{ inputs.lane }}
+  cancel-in-progress: false
+
 jobs:
   distribute:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 💡 Issue
- Resolved: #243

## 🌱 Key changes
- `.github/workflows/distribute.yml` 추가 (Firebase App Distribution 수동 배포 워크플로우)
  - 트리거: `workflow_dispatch` (GitHub Actions UI 또는 REST API로 수동 실행)
  - `lane` input: `distribute_qa` (versionCode 증가 + 배포) / `distribute_qa_test` (빌드만 + 배포) — choice
  - `branch` input: 배포할 브랜치명 (default: `develop`)
  - 기존 `.github/actions/build-configuration` 재사용 (keystore, local.properties 설정)
  - `ruby/setup-ruby@v1` + `bundler-cache: true` 로 Fastlane 설치
  - `FIREBASE_CREDENTIAL_JSON` secret을 `fastlane/credentials.json`으로 복원 후 Fastlane 실행
  - `distribute_qa` 레인의 git commit + push를 위해 `permissions: contents: write` 및 Git config 설정

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Firebase App Distribution을 위한 자동화된 배포 워크플로우 추가
  * 수동 트리거로 분기와 배포 라인 선택 가능(QA용 배포 지원)
  * Android 빌드 및 Fastlane 기반 배포 과정 통합으로 배포 효율성 향상 및 자동화 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->